### PR TITLE
Fix width of formatted addresses, and add Debug implementation

### DIFF
--- a/src/paging.rs
+++ b/src/paging.rs
@@ -40,7 +40,7 @@ impl<T> From<*mut T> for VirtualAddress {
 
 impl Display for VirtualAddress {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{:#016x}", self.0)
+        write!(f, "{:#018x}", self.0)
     }
 }
 
@@ -61,7 +61,7 @@ pub struct PhysicalAddress(pub usize);
 
 impl Display for PhysicalAddress {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{:#016x}", self.0)
+        write!(f, "{:#018x}", self.0)
     }
 }
 

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -44,6 +44,12 @@ impl Display for VirtualAddress {
     }
 }
 
+impl Debug for VirtualAddress {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        write!(f, "VirtualAddress({})", self)
+    }
+}
+
 /// A range of virtual addresses which may be mapped in a page table.
 #[derive(Clone, Eq, PartialEq)]
 pub struct MemoryRegion(Range<VirtualAddress>);
@@ -56,6 +62,12 @@ pub struct PhysicalAddress(pub usize);
 impl Display for PhysicalAddress {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         write!(f, "{:#016x}", self.0)
+    }
+}
+
+impl Debug for PhysicalAddress {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        write!(f, "PhysicalAddress({})", self)
     }
 }
 


### PR DESCRIPTION
The length specified in the format string includes the "0x" at the start, so it should be two more than the number of digits we want. Implementing `Debug` is useful for being able to derive it on other types which contain a `VirtualAddress` or `PhysicalAddress`.