### PR TITLE
Add bounds check to map_range.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,3 +42,6 @@ pub mod idmap;
 pub mod paging;
 
 extern crate alloc;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct AddressRangeError;


### PR DESCRIPTION
Return an error if the caller tries to map virtual addresses which are outside the range supported by the page table given its root level.