### PR TITLE
Implement useful traits for address types and `MemoryRegion`

### DIFF
--- a/src/paging.rs
+++ b/src/paging.rs
@@ -83,6 +83,14 @@ impl Debug for PhysicalAddress {
     }
 }
 
+impl Sub for PhysicalAddress {
+    type Output = usize;
+
+    fn sub(self, other: Self) -> Self::Output {
+        self.0 - other.0
+    }
+}
+
 /// Returns the size in bytes of the address space covered by a single entry in the page table at
 /// the given level.
 fn granularity_at_level(level: usize) -> usize {
@@ -520,6 +528,23 @@ mod tests {
     fn subtract_virtual_address_overflow() {
         let low = VirtualAddress(0x12);
         let high = VirtualAddress(0x1234);
+
+        // This would overflow, so should panic.
+        let _ = low - high;
+    }
+
+    #[test]
+    fn subtract_physical_address() {
+        let low = PhysicalAddress(0x12);
+        let high = PhysicalAddress(0x1234);
+        assert_eq!(high - low, 0x1222);
+    }
+
+    #[test]
+    #[should_panic]
+    fn subtract_physical_address_overflow() {
+        let low = PhysicalAddress(0x12);
+        let high = PhysicalAddress(0x1234);
 
         // This would overflow, so should panic.
         let _ = low - high;

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -11,7 +11,7 @@ use bitflags::bitflags;
 use core::alloc::Layout;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::marker::PhantomData;
-use core::ops::Range;
+use core::ops::{Range, Sub};
 use core::ptr::NonNull;
 
 const PAGE_SHIFT: usize = 12;
@@ -51,6 +51,14 @@ impl Display for VirtualAddress {
 impl Debug for VirtualAddress {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         write!(f, "VirtualAddress({})", self)
+    }
+}
+
+impl Sub for VirtualAddress {
+    type Output = usize;
+
+    fn sub(self, other: Self) -> Self::Output {
+        self.0 - other.0
     }
 }
 
@@ -498,5 +506,22 @@ mod tests {
             &format!("{:?}", region),
             "0x0000000000001000..0x0000000000057000"
         );
+    }
+
+    #[test]
+    fn subtract_virtual_address() {
+        let low = VirtualAddress(0x12);
+        let high = VirtualAddress(0x1234);
+        assert_eq!(high - low, 0x1222);
+    }
+
+    #[test]
+    #[should_panic]
+    fn subtract_virtual_address_overflow() {
+        let low = VirtualAddress(0x12);
+        let high = VirtualAddress(0x1234);
+
+        // This would overflow, so should panic.
+        let _ = low - high;
     }
 }

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -121,6 +121,12 @@ impl MemoryRegion {
     }
 }
 
+impl From<Range<VirtualAddress>> for MemoryRegion {
+    fn from(range: Range<VirtualAddress>) -> Self {
+        Self::new(range.start.0, range.end.0)
+    }
+}
+
 impl Display for MemoryRegion {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         write!(f, "{}..{}", self.0.start, self.0.end)

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -11,7 +11,7 @@ use bitflags::bitflags;
 use core::alloc::Layout;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::marker::PhantomData;
-use core::ops::{Range, Sub};
+use core::ops::{Add, Range, Sub};
 use core::ptr::NonNull;
 
 const PAGE_SHIFT: usize = 12;
@@ -62,6 +62,14 @@ impl Sub for VirtualAddress {
     }
 }
 
+impl Add<usize> for VirtualAddress {
+    type Output = Self;
+
+    fn add(self, other: usize) -> Self {
+        Self(self.0 + other)
+    }
+}
+
 /// A range of virtual addresses which may be mapped in a page table.
 #[derive(Clone, Eq, PartialEq)]
 pub struct MemoryRegion(Range<VirtualAddress>);
@@ -88,6 +96,14 @@ impl Sub for PhysicalAddress {
 
     fn sub(self, other: Self) -> Self::Output {
         self.0 - other.0
+    }
+}
+
+impl Add<usize> for PhysicalAddress {
+    type Output = Self;
+
+    fn add(self, other: usize) -> Self {
+        Self(self.0 + other)
     }
 }
 
@@ -534,6 +550,11 @@ mod tests {
     }
 
     #[test]
+    fn add_virtual_address() {
+        assert_eq!(VirtualAddress(0x1234) + 0x42, VirtualAddress(0x1276));
+    }
+
+    #[test]
     fn subtract_physical_address() {
         let low = PhysicalAddress(0x12);
         let high = PhysicalAddress(0x1234);
@@ -548,5 +569,10 @@ mod tests {
 
         // This would overflow, so should panic.
         let _ = low - high;
+    }
+
+    #[test]
+    fn add_physical_address() {
+        assert_eq!(PhysicalAddress(0x1234) + 0x42, PhysicalAddress(0x1276));
     }
 }


### PR DESCRIPTION
Adds addition and subtraction for `VirtualAddress` and `PhysicalAddress`, and conversion from `Range<VirtualAddress>` to `MemoryRegion` (with the same alignment logic as `MemoryRegion::new`).