### PR TITLE
Add support for linear mapping

### DIFF
--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -38,21 +38,21 @@ mod tests {
     #[test]
     fn map_valid() {
         // A single byte at the start of the address space.
-        let mut idmap = Mapping::new(IdTranslation, 1, 1);
+        let mut idmap = IdMap::new(IdTranslation, 1, 1);
         assert_eq!(
             idmap.map_range(&MemoryRegion::new(0, 1), Attributes::NORMAL),
             Ok(())
         );
 
         // Two pages at the start of the address space.
-        let mut idmap = Mapping::new(IdTranslation, 1, 1);
+        let mut idmap = IdMap::new(IdTranslation, 1, 1);
         assert_eq!(
             idmap.map_range(&MemoryRegion::new(0, PAGE_SIZE * 2), Attributes::NORMAL),
             Ok(())
         );
 
         // A single byte at the end of the address space.
-        let mut idmap = Mapping::new(IdTranslation, 1, 1);
+        let mut idmap = IdMap::new(IdTranslation, 1, 1);
         assert_eq!(
             idmap.map_range(
                 &MemoryRegion::new(
@@ -65,7 +65,7 @@ mod tests {
         );
 
         // The entire valid address space.
-        let mut idmap = Mapping::new(IdTranslation, 1, 1);
+        let mut idmap = IdMap::new(IdTranslation, 1, 1);
         assert_eq!(
             idmap.map_range(
                 &MemoryRegion::new(0, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn map_out_of_range() {
-        let mut idmap = Mapping::new(IdTranslation, 1, 1);
+        let mut idmap = IdMap::new(IdTranslation, 1, 1);
 
         // One byte, just past the edge of the valid range.
         assert_eq!(

--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     paging::{PhysicalAddress, Translation, VirtualAddress},
-    Mapping,
+    MapError, Mapping,
 };
 
 /// Identity mapping, where every virtual address is either unmapped or mapped to the identical IPA.
@@ -14,8 +14,8 @@ use crate::{
 pub struct IdTranslation;
 
 impl Translation for IdTranslation {
-    fn virtual_to_physical(&self, va: VirtualAddress) -> PhysicalAddress {
-        PhysicalAddress(va.0)
+    fn virtual_to_physical(&self, va: VirtualAddress) -> Result<PhysicalAddress, MapError> {
+        Ok(PhysicalAddress(va.0))
     }
 
     fn physical_to_virtual(&self, pa: PhysicalAddress) -> VirtualAddress {
@@ -30,7 +30,7 @@ mod tests {
     use super::*;
     use crate::{
         paging::{Attributes, MemoryRegion, PAGE_SIZE},
-        AddressRangeError,
+        MapError,
     };
 
     const MAX_ADDRESS_FOR_ROOT_LEVEL_1: usize = 1 << 39;
@@ -88,7 +88,9 @@ mod tests {
                 ),
                 Attributes::NORMAL
             ),
-            Err(AddressRangeError)
+            Err(MapError::AddressRange(VirtualAddress(
+                MAX_ADDRESS_FOR_ROOT_LEVEL_1 + PAGE_SIZE
+            )))
         );
 
         // From 0 to just past the valid range.
@@ -97,7 +99,9 @@ mod tests {
                 &MemoryRegion::new(0, MAX_ADDRESS_FOR_ROOT_LEVEL_1 + 1,),
                 Attributes::NORMAL
             ),
-            Err(AddressRangeError)
+            Err(MapError::AddressRange(VirtualAddress(
+                MAX_ADDRESS_FOR_ROOT_LEVEL_1 + PAGE_SIZE
+            )))
         );
     }
 }

--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -5,67 +5,13 @@
 //! Functionality for managing page tables with identity mapping.
 
 use crate::{
-    paging::{Attributes, MemoryRegion, PhysicalAddress, RootTable, Translation, VirtualAddress},
-    AddressRangeError,
+    paging::{PhysicalAddress, Translation, VirtualAddress},
+    Mapping,
 };
-#[cfg(target_arch = "aarch64")]
-use core::arch::asm;
 
-/// Manages a level 1 page-table using identity mapping, where every virtual address is either
-/// unmapped or mapped to the identical IPA.
-///
-/// Mappings should be added with [`map_range`](Self::map_range) before calling
-/// [`activate`](Self::activate) to start using the new page table. To make changes which may
-/// require break-before-make semantics you must first call [`deactivate`](Self::deactivate) to
-/// switch back to a previous static page table, and then `activate` again after making the desired
-/// changes.
-///
-/// # Example
-///
-/// ```
-/// use aarch64_paging::{
-///     idmap::IdMap,
-///     paging::{Attributes, MemoryRegion},
-/// };
-///
-/// const ASID: usize = 1;
-/// const ROOT_LEVEL: usize = 1;
-///
-/// // Create a new page table with identity mapping.
-/// let mut idmap = IdMap::new(ASID, ROOT_LEVEL);
-/// // Map a 2 MiB region of memory as read-write.
-/// idmap.map_range(
-///     &MemoryRegion::new(0x80200000, 0x80400000),
-///     Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::EXECUTE_NEVER,
-/// ).unwrap();
-/// // Set `TTBR0_EL1` to activate the page table.
-/// # #[cfg(target_arch = "aarch64")]
-/// idmap.activate();
-///
-/// // Write something to the memory...
-///
-/// // Restore `TTBR0_EL1` to its earlier value while we modify the page table.
-/// # #[cfg(target_arch = "aarch64")]
-/// idmap.deactivate();
-/// // Now change the mapping to read-only and executable.
-/// idmap.map_range(
-///     &MemoryRegion::new(0x80200000, 0x80400000),
-///     Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::READ_ONLY,
-/// ).unwrap();
-/// # #[cfg(target_arch = "aarch64")]
-/// idmap.activate();
-/// ```
-#[derive(Debug)]
-pub struct IdMap {
-    root: RootTable<IdTranslation>,
-    #[allow(unused)]
-    asid: usize,
-    #[allow(unused)]
-    previous_ttbr: Option<usize>,
-}
-
+/// Identity mapping, where every virtual address is either unmapped or mapped to the identical IPA.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-struct IdTranslation;
+pub struct IdTranslation;
 
 impl Translation for IdTranslation {
     fn virtual_to_physical(&self, va: VirtualAddress) -> PhysicalAddress {
@@ -77,123 +23,36 @@ impl Translation for IdTranslation {
     }
 }
 
-impl IdMap {
-    /// Creates a new identity-mapping page table with the given ASID and root level.
-    pub fn new(asid: usize, rootlevel: usize) -> IdMap {
-        IdMap {
-            root: RootTable::new(IdTranslation, rootlevel),
-            asid,
-            previous_ttbr: None,
-        }
-    }
-
-    /// Activates the page table by setting `TTBR0_EL1` to point to it, and saves the previous value
-    /// of `TTBR0_EL1` so that it may later be restored by [`deactivate`](Self::deactivate).
-    ///
-    /// Panics if a previous value of `TTBR0_EL1` is already saved and not yet used by a call to
-    /// `deactivate`.
-    #[cfg(target_arch = "aarch64")]
-    pub fn activate(&mut self) {
-        assert!(self.previous_ttbr.is_none());
-
-        let mut previous_ttbr;
-        unsafe {
-            // Safe because we trust that self.root.to_physical() returns a valid physical address
-            // of a page table, and the `Drop` implementation will reset `TTRB0_EL1` before it
-            // becomes invalid.
-            asm!(
-                "mrs   {previous_ttbr}, ttbr0_el1",
-                "msr   ttbr0_el1, {ttbrval}",
-                "isb",
-                ttbrval = in(reg) self.root.to_physical().0 | (self.asid << 48),
-                previous_ttbr = out(reg) previous_ttbr,
-                options(preserves_flags),
-            );
-        }
-        self.previous_ttbr = Some(previous_ttbr);
-    }
-
-    /// Deactivates the page table, by setting `TTBR0_EL1` back to the value it had before
-    /// [`activate`](Self::activate) was called, and invalidating the TLB for this page table's
-    /// configured ASID.
-    ///
-    /// Panics if there is no saved `TTRB0_EL1` value because `activate` has not previously been
-    /// called.
-    #[cfg(target_arch = "aarch64")]
-    pub fn deactivate(&mut self) {
-        unsafe {
-            // Safe because this just restores the previously saved value of `TTBR0_EL1`, which must
-            // have been valid.
-            asm!(
-                "msr   ttbr0_el1, {ttbrval}",
-                "isb",
-                "tlbi  aside1, {asid}",
-                "dsb   nsh",
-                "isb",
-                asid = in(reg) self.asid << 48,
-                ttbrval = in(reg) self.previous_ttbr.unwrap(),
-                options(preserves_flags),
-            );
-        }
-        self.previous_ttbr = None;
-    }
-
-    /// Maps the given range of virtual addresses to the identical physical addresses with the given
-    /// flags.
-    ///
-    /// This should generally only be called while the page table is not active. In particular, any
-    /// change that may require break-before-make per the architecture must be made while the page
-    /// table is inactive. Mapping a previously unmapped memory range may be done while the page
-    /// table is active.
-    pub fn map_range(
-        &mut self,
-        range: &MemoryRegion,
-        flags: Attributes,
-    ) -> Result<(), AddressRangeError> {
-        self.root.map_range(range, flags)?;
-        #[cfg(target_arch = "aarch64")]
-        unsafe {
-            // Safe because this is just a memory barrier.
-            asm!("dsb ishst");
-        }
-        Ok(())
-    }
-}
-
-impl Drop for IdMap {
-    fn drop(&mut self) {
-        if self.previous_ttbr.is_some() {
-            #[cfg(target_arch = "aarch64")]
-            self.deactivate();
-        }
-    }
-}
+pub type IdMap = Mapping<IdTranslation>;
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::paging::PAGE_SIZE;
+    use crate::{
+        paging::{Attributes, MemoryRegion, PAGE_SIZE},
+        AddressRangeError,
+    };
 
     const MAX_ADDRESS_FOR_ROOT_LEVEL_1: usize = 1 << 39;
 
     #[test]
     fn map_valid() {
         // A single byte at the start of the address space.
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = Mapping::new(IdTranslation, 1, 1);
         assert_eq!(
             idmap.map_range(&MemoryRegion::new(0, 1), Attributes::NORMAL),
             Ok(())
         );
 
         // Two pages at the start of the address space.
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = Mapping::new(IdTranslation, 1, 1);
         assert_eq!(
             idmap.map_range(&MemoryRegion::new(0, PAGE_SIZE * 2), Attributes::NORMAL),
             Ok(())
         );
 
         // A single byte at the end of the address space.
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = Mapping::new(IdTranslation, 1, 1);
         assert_eq!(
             idmap.map_range(
                 &MemoryRegion::new(
@@ -206,7 +65,7 @@ mod tests {
         );
 
         // The entire valid address space.
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = Mapping::new(IdTranslation, 1, 1);
         assert_eq!(
             idmap.map_range(
                 &MemoryRegion::new(0, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
@@ -218,7 +77,7 @@ mod tests {
 
     #[test]
     fn map_out_of_range() {
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = Mapping::new(IdTranslation, 1, 1);
 
         // One byte, just past the edge of the valid range.
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,8 @@ use core::arch::asm;
 use core::fmt::{self, Display, Formatter};
 use paging::{Attributes, MemoryRegion, RootTable, Translation};
 
+/// The address requested to be mapped was out of the range supported by the page table
+/// configuration.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct AddressRangeError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,16 +17,15 @@
 //!
 //! ```
 //! use aarch64_paging::{
-//!     idmap::IdTranslation,
+//!     idmap::{IdMap, IdTranslation},
 //!     paging::{Attributes, MemoryRegion},
-//!     Mapping,
 //! };
 //!
 //! const ASID: usize = 1;
 //! const ROOT_LEVEL: usize = 1;
 //!
 //! // Create a new page table with identity mapping.
-//! let mut idmap = Mapping::new(IdTranslation, ASID, ROOT_LEVEL);
+//! let mut idmap = IdMap::new(IdTranslation, ASID, ROOT_LEVEL);
 //! // Map a 2 MiB region of memory as read-only.
 //! idmap.map_range(
 //!     &MemoryRegion::new(0x80200000, 0x80400000),
@@ -73,16 +72,15 @@ impl Display for AddressRangeError {
 ///
 /// ```
 /// use aarch64_paging::{
-///     idmap::IdTranslation,
+///     idmap::{IdMap, IdTranslation},
 ///     paging::{Attributes, MemoryRegion},
-///     Mapping,
 /// };
 ///
 /// const ASID: usize = 1;
 /// const ROOT_LEVEL: usize = 1;
 ///
 /// // Create a new page table with identity mapping.
-/// let mut idmap = Mapping::new(IdTranslation, ASID, ROOT_LEVEL);
+/// let mut idmap = IdMap::new(IdTranslation, ASID, ROOT_LEVEL);
 /// // Map a 2 MiB region of memory as read-write.
 /// idmap.map_range(
 ///     &MemoryRegion::new(0x80200000, 0x80400000),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,9 @@
 //!   - EL1
 //!   - 4 KiB pages
 //!
-//! Full support is only provided for identity mapping; for other mapping schemes the user of the
-//! library must implement some functionality themself including an implementation of the
-//! [`Translation`](paging::Translation) trait.
+//! Full support is only provided for identity mapping and linear mapping; for other mapping schemes
+//! the user of the library must implement some functionality themself including an implementation
+//! of the [`Translation`](paging::Translation) trait.
 //!
 //! # Example
 //!
@@ -39,6 +39,7 @@
 #![no_std]
 
 pub mod idmap;
+pub mod linearmap;
 pub mod paging;
 
 extern crate alloc;

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -48,21 +48,21 @@ mod tests {
     #[test]
     fn map_valid() {
         // A single byte at the start of the address space.
-        let mut pagetable = Mapping::new(LinearTranslation::new(4096), 1, 1);
+        let mut pagetable = LinearMap::new(LinearTranslation::new(4096), 1, 1);
         assert_eq!(
             pagetable.map_range(&MemoryRegion::new(0, 1), Attributes::NORMAL),
             Ok(())
         );
 
         // Two pages at the start of the address space.
-        let mut pagetable = Mapping::new(LinearTranslation::new(4096), 1, 1);
+        let mut pagetable = LinearMap::new(LinearTranslation::new(4096), 1, 1);
         assert_eq!(
             pagetable.map_range(&MemoryRegion::new(0, PAGE_SIZE * 2), Attributes::NORMAL),
             Ok(())
         );
 
         // A single byte at the end of the address space.
-        let mut pagetable = Mapping::new(LinearTranslation::new(4096), 1, 1);
+        let mut pagetable = LinearMap::new(LinearTranslation::new(4096), 1, 1);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(
@@ -75,7 +75,7 @@ mod tests {
         );
 
         // The entire valid address space.
-        let mut pagetable = Mapping::new(LinearTranslation::new(4096), 1, 1);
+        let mut pagetable = LinearMap::new(LinearTranslation::new(4096), 1, 1);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
@@ -87,7 +87,7 @@ mod tests {
 
     #[test]
     fn map_out_of_range() {
-        let mut pagetable = Mapping::new(LinearTranslation::new(4096), 1, 1);
+        let mut pagetable = LinearMap::new(LinearTranslation::new(4096), 1, 1);
 
         // One byte, just past the edge of the valid range.
         assert_eq!(

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -106,6 +106,52 @@ mod tests {
     }
 
     #[test]
+    fn map_valid_negative_offset() {
+        // A single byte which maps to IPA 0.
+        let mut pagetable = LinearMap::new(LinearTranslation::new(-(PAGE_SIZE as isize)), 1, 1);
+        assert_eq!(
+            pagetable.map_range(
+                &MemoryRegion::new(PAGE_SIZE, PAGE_SIZE + 1),
+                Attributes::NORMAL
+            ),
+            Ok(())
+        );
+
+        // Two pages at the start of the address space.
+        let mut pagetable = LinearMap::new(LinearTranslation::new(-(PAGE_SIZE as isize)), 1, 1);
+        assert_eq!(
+            pagetable.map_range(
+                &MemoryRegion::new(PAGE_SIZE, PAGE_SIZE * 3),
+                Attributes::NORMAL
+            ),
+            Ok(())
+        );
+
+        // A single byte at the end of the address space.
+        let mut pagetable = LinearMap::new(LinearTranslation::new(-(PAGE_SIZE as isize)), 1, 1);
+        assert_eq!(
+            pagetable.map_range(
+                &MemoryRegion::new(
+                    MAX_ADDRESS_FOR_ROOT_LEVEL_1 - 1,
+                    MAX_ADDRESS_FOR_ROOT_LEVEL_1
+                ),
+                Attributes::NORMAL
+            ),
+            Ok(())
+        );
+
+        // The entire valid address space.
+        let mut pagetable = LinearMap::new(LinearTranslation::new(-(PAGE_SIZE as isize)), 1, 1);
+        assert_eq!(
+            pagetable.map_range(
+                &MemoryRegion::new(PAGE_SIZE, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
+                Attributes::NORMAL
+            ),
+            Ok(())
+        );
+    }
+
+    #[test]
     fn map_out_of_range() {
         let mut pagetable = LinearMap::new(LinearTranslation::new(4096), 1, 1);
 

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -5,70 +5,22 @@
 //! Functionality for managing page tables with linear mapping.
 
 use crate::{
-    paging::{Attributes, MemoryRegion, PhysicalAddress, RootTable, Translation, VirtualAddress},
-    AddressRangeError,
+    paging::{PhysicalAddress, Translation, VirtualAddress},
+    Mapping,
 };
-#[cfg(target_arch = "aarch64")]
-use core::arch::asm;
 
-/// Manages a level 1 page-table using linear mapping, where every virtual address is either
-/// unmapped or mapped to an IPA with a fixed offset.
-///
-/// Mappings should be added with [`map_range`](Self::map_range) before calling
-/// [`activate`](Self::activate) to start using the new page table. To make changes which may
-/// require break-before-make semantics you must first call [`deactivate`](Self::deactivate) to
-/// switch back to a previous static page table, and then `activate` again after making the desired
-/// changes.
-///
-/// # Example
-///
-/// ```
-/// use aarch64_paging::{
-///     linearmap::LinearMap,
-///     paging::{Attributes, MemoryRegion},
-/// };
-///
-/// const ASID: usize = 1;
-/// const ROOT_LEVEL: usize = 1;
-/// const OFFSET: isize = 4096;
-///
-/// // Create a new page table with linear mapping.
-/// let mut pagetable = LinearMap::new(ASID, ROOT_LEVEL, OFFSET);
-/// // Map a 2 MiB region of memory as read-write.
-/// pagetable.map_range(
-///     &MemoryRegion::new(0x80200000, 0x80400000),
-///     Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::EXECUTE_NEVER,
-/// ).unwrap();
-/// // Set `TTBR0_EL1` to activate the page table.
-/// # #[cfg(target_arch = "aarch64")]
-/// pagetable.activate();
-///
-/// // Write something to the memory...
-///
-/// // Restore `TTBR0_EL1` to its earlier value while we modify the page table.
-/// # #[cfg(target_arch = "aarch64")]
-/// pagetable.deactivate();
-/// // Now change the mapping to read-only and executable.
-/// pagetable.map_range(
-///     &MemoryRegion::new(0x80200000, 0x80400000),
-///     Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::READ_ONLY,
-/// ).unwrap();
-/// # #[cfg(target_arch = "aarch64")]
-/// pagetable.activate();
-/// ```
-#[derive(Debug)]
-pub struct LinearMap {
-    root: RootTable<LinearTranslation>,
-    #[allow(unused)]
-    asid: usize,
-    #[allow(unused)]
-    previous_ttbr: Option<usize>,
-}
-
+/// Linear mapping, where every virtual address is either unmapped or mapped to an IPA with a fixed
+/// offset.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-struct LinearTranslation {
+pub struct LinearTranslation {
     /// The offset from a virtual address to the corresponding (intermediate) physical address.
     offset: isize,
+}
+
+impl LinearTranslation {
+    pub fn new(offset: isize) -> Self {
+        Self { offset }
+    }
 }
 
 impl Translation for LinearTranslation {
@@ -81,123 +33,36 @@ impl Translation for LinearTranslation {
     }
 }
 
-impl LinearMap {
-    /// Creates a new identity-mapping page table with the given ASID and root level.
-    pub fn new(asid: usize, rootlevel: usize, offset: isize) -> LinearMap {
-        LinearMap {
-            root: RootTable::new(LinearTranslation { offset }, rootlevel),
-            asid,
-            previous_ttbr: None,
-        }
-    }
-
-    /// Activates the page table by setting `TTBR0_EL1` to point to it, and saves the previous value
-    /// of `TTBR0_EL1` so that it may later be restored by [`deactivate`](Self::deactivate).
-    ///
-    /// Panics if a previous value of `TTBR0_EL1` is already saved and not yet used by a call to
-    /// `deactivate`.
-    #[cfg(target_arch = "aarch64")]
-    pub fn activate(&mut self) {
-        assert!(self.previous_ttbr.is_none());
-
-        let mut previous_ttbr;
-        unsafe {
-            // Safe because we trust that self.root.to_physical() returns a valid physical address
-            // of a page table, and the `Drop` implementation will reset `TTRB0_EL1` before it
-            // becomes invalid.
-            asm!(
-                "mrs   {previous_ttbr}, ttbr0_el1",
-                "msr   ttbr0_el1, {ttbrval}",
-                "isb",
-                ttbrval = in(reg) self.root.to_physical().0 | (self.asid << 48),
-                previous_ttbr = out(reg) previous_ttbr,
-                options(preserves_flags),
-            );
-        }
-        self.previous_ttbr = Some(previous_ttbr);
-    }
-
-    /// Deactivates the page table, by setting `TTBR0_EL1` back to the value it had before
-    /// [`activate`](Self::activate) was called, and invalidating the TLB for this page table's
-    /// configured ASID.
-    ///
-    /// Panics if there is no saved `TTRB0_EL1` value because `activate` has not previously been
-    /// called.
-    #[cfg(target_arch = "aarch64")]
-    pub fn deactivate(&mut self) {
-        unsafe {
-            // Safe because this just restores the previously saved value of `TTBR0_EL1`, which must
-            // have been valid.
-            asm!(
-                "msr   ttbr0_el1, {ttbrval}",
-                "isb",
-                "tlbi  aside1, {asid}",
-                "dsb   nsh",
-                "isb",
-                asid = in(reg) self.asid << 48,
-                ttbrval = in(reg) self.previous_ttbr.unwrap(),
-                options(preserves_flags),
-            );
-        }
-        self.previous_ttbr = None;
-    }
-
-    /// Maps the given range of virtual addresses to the identical physical addresses with the given
-    /// flags.
-    ///
-    /// This should generally only be called while the page table is not active. In particular, any
-    /// change that may require break-before-make per the architecture must be made while the page
-    /// table is inactive. Mapping a previously unmapped memory range may be done while the page
-    /// table is active.
-    pub fn map_range(
-        &mut self,
-        range: &MemoryRegion,
-        flags: Attributes,
-    ) -> Result<(), AddressRangeError> {
-        self.root.map_range(range, flags)?;
-        #[cfg(target_arch = "aarch64")]
-        unsafe {
-            // Safe because this is just a memory barrier.
-            asm!("dsb ishst");
-        }
-        Ok(())
-    }
-}
-
-impl Drop for LinearMap {
-    fn drop(&mut self) {
-        if self.previous_ttbr.is_some() {
-            #[cfg(target_arch = "aarch64")]
-            self.deactivate();
-        }
-    }
-}
+pub type LinearMap = Mapping<LinearTranslation>;
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::paging::PAGE_SIZE;
+    use crate::{
+        paging::{Attributes, MemoryRegion, PAGE_SIZE},
+        AddressRangeError,
+    };
 
     const MAX_ADDRESS_FOR_ROOT_LEVEL_1: usize = 1 << 39;
 
     #[test]
     fn map_valid() {
         // A single byte at the start of the address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096);
+        let mut pagetable = Mapping::new(LinearTranslation::new(4096), 1, 1);
         assert_eq!(
             pagetable.map_range(&MemoryRegion::new(0, 1), Attributes::NORMAL),
             Ok(())
         );
 
         // Two pages at the start of the address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096);
+        let mut pagetable = Mapping::new(LinearTranslation::new(4096), 1, 1);
         assert_eq!(
             pagetable.map_range(&MemoryRegion::new(0, PAGE_SIZE * 2), Attributes::NORMAL),
             Ok(())
         );
 
         // A single byte at the end of the address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096);
+        let mut pagetable = Mapping::new(LinearTranslation::new(4096), 1, 1);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(
@@ -210,7 +75,7 @@ mod tests {
         );
 
         // The entire valid address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096);
+        let mut pagetable = Mapping::new(LinearTranslation::new(4096), 1, 1);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
@@ -222,7 +87,7 @@ mod tests {
 
     #[test]
     fn map_out_of_range() {
-        let mut pagetable = LinearMap::new(1, 1, 4096);
+        let mut pagetable = Mapping::new(LinearTranslation::new(4096), 1, 1);
 
         // One byte, just past the edge of the valid range.
         assert_eq!(

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -116,7 +116,12 @@ fn granularity_at_level(level: usize) -> usize {
 /// physical addresses used in the page tables can be converted into virtual addresses that can be
 /// used to access their contents from the code.
 pub trait Translation {
+    /// Given a virtual address, returns the physical address to which it should be mapped.
+    ///
+    /// This must at least define mappings for any memory which might be allocated.
     fn virtual_to_physical(&self, va: VirtualAddress) -> PhysicalAddress;
+
+    /// Given the physical address of a subtable, returns the virtual address at which it is mapped.
     fn physical_to_virtual(&self, pa: PhysicalAddress) -> VirtualAddress;
 }
 

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -69,6 +69,14 @@ impl Add<usize> for VirtualAddress {
     }
 }
 
+impl Sub<usize> for VirtualAddress {
+    type Output = Self;
+
+    fn sub(self, other: usize) -> Self {
+        Self(self.0 - other)
+    }
+}
+
 /// A range of virtual addresses which may be mapped in a page table.
 #[derive(Clone, Eq, PartialEq)]
 pub struct MemoryRegion(Range<VirtualAddress>);
@@ -103,6 +111,14 @@ impl Add<usize> for PhysicalAddress {
 
     fn add(self, other: usize) -> Self {
         Self(self.0 + other)
+    }
+}
+
+impl Sub<usize> for PhysicalAddress {
+    type Output = Self;
+
+    fn sub(self, other: usize) -> Self {
+        Self(self.0 - other)
     }
 }
 


### PR DESCRIPTION
This required some refactoring because the methods on the `Translation` trait need to take `self` to know the offset, and so the `Translation` needs to be passed around to the various methods which access the page table. I've achieved this by adding it as a field on the `PageTableWithLevel`.

To avoid duplicating code I've moved the common methods from `IdMap` out to a new shared struct called `Mapping`, which takes the `Translation` on construction. `Translation` is then implemented by `IdTranslation` and `LinearTranslation`, and `IdMap` becomes an alias for `Mapping<IdTranslation>`.

Suggestions are welcome on better names.