### PR TITLE
Prepare for more complex mapping schemes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,8 @@ jobs:
         run: cargo build --target=aarch64-unknown-none
       - name: Run tests
         run: cargo test
+      - name: Run tests without default features
+        run: cargo test --no-default-features
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+## Unreleased
+
+### Breaking changes
+
+- Made `Translation` trait responsible for allocating page tables. This should help make it possible
+  to use more complex mapping schemes, and to construct page tables in a different context to where
+  they are used.
+- Renamed `AddressRangeError` to `MapError`, which is now an enum with two variants and implements
+  `Display`.
+
+### New features
+
+- Made `alloc` dependency optional via a feature flag.
+- Added support for linear mappings with new `LinearMap`.
+- Implemented subtraction of usize from address types.
+
+### Bugfixes
+
+- Fixed memory leak introduced in 0.2.0: dropping a page table will now actually free its memory.
+
+## 0.2.1
+
+### New features
+
+- Implemented `Debug` and `Display` for `MemoryRegion`.
+- Implemented `From<Range<VirtualAddress>>` for `MemoryRegion`.
+- Implemented arithmetic operations for `PhysicalAddress` and `VirtualAddress`.
+
+## 0.2.0
+
+### Breaking changes
+
+- Added bounds check to `IdMap::map_range`; it will now return an error if you attempt to map a
+  virtual address outside the range of the page table given its configured root level.
+
+### New features
+
+- Implemented `Debug` for `PhysicalAddress` and `VirtualAddress`.
+- Validate that chosen root level is supported.
+
+### Bugfixes
+
+- Fixed bug in `Display` and `Drop` implementation for `RootTable` that would result in a crash for
+  any pagetable with non-zero mappings.
+- Fixed `Display` implementation for `PhysicalAddress` and `VirtualAddress` to use correct number of
+  digits.
+
+## 0.1.0
+
+Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   they are used.
 - Renamed `AddressRangeError` to `MapError`, which is now an enum with two variants and implements
   `Display`.
+- `From<*const T>` and `From<*mut T>` are no longer implemented for `VirtualAddress`.
 
 ### New features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,10 @@ categories = ["embedded", "no-std", "hardware-support"]
 [dependencies]
 bitflags = "1.3.2"
 
+[features]
+default = ["alloc"]
+alloc = []
+
 [package.metadata.docs.rs]
+all-features = true
 default-target = "aarch64-unknown-none"

--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -3,6 +3,8 @@
 // See LICENSE-APACHE and LICENSE-MIT for details.
 
 //! Functionality for managing page tables with identity mapping.
+//!
+//! See [`IdMap`] for details on how to use it.
 
 use crate::{
     paging::{
@@ -125,6 +127,11 @@ impl IdMap {
     /// change that may require break-before-make per the architecture must be made while the page
     /// table is inactive. Mapping a previously unmapped memory range may be done while the page
     /// table is active.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MapError::AddressRange`] if the largest address in the `range` is greater than the
+    /// largest virtual address covered by the page table given its root level.
     pub fn map_range(&mut self, range: &MemoryRegion, flags: Attributes) -> Result<(), MapError> {
         let pa = IdTranslation::virtual_to_physical(range.start());
         self.mapping.map_range(range, pa, flags)

--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -5,17 +5,34 @@
 //! Functionality for managing page tables with identity mapping.
 
 use crate::{
-    paging::{PhysicalAddress, Translation, VirtualAddress},
+    paging::{
+        deallocate, Attributes, MemoryRegion, PageTable, PhysicalAddress, Translation,
+        VirtualAddress,
+    },
     MapError, Mapping,
 };
+use core::ptr::NonNull;
 
 /// Identity mapping, where every virtual address is either unmapped or mapped to the identical IPA.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct IdTranslation;
 
+impl IdTranslation {
+    fn virtual_to_physical(va: VirtualAddress) -> PhysicalAddress {
+        PhysicalAddress(va.0)
+    }
+}
+
 impl Translation for IdTranslation {
-    fn virtual_to_physical(&self, va: VirtualAddress) -> Result<PhysicalAddress, MapError> {
-        Ok(PhysicalAddress(va.0))
+    fn allocate_table(&self) -> (NonNull<PageTable>, PhysicalAddress) {
+        let table = PageTable::new();
+        let va = VirtualAddress::from(table.as_ptr());
+
+        (table, Self::virtual_to_physical(va))
+    }
+
+    unsafe fn deallocate_table(&self, page_table: NonNull<PageTable>) {
+        deallocate(page_table);
     }
 
     fn physical_to_virtual(&self, pa: PhysicalAddress) -> VirtualAddress {
@@ -23,7 +40,96 @@ impl Translation for IdTranslation {
     }
 }
 
-pub type IdMap = Mapping<IdTranslation>;
+/// Manages a level 1 page table using identity mapping, where every virtual address is either
+/// unmapped or mapped to the identical IPA.
+///
+/// Mappings should be added with [`map_range`](Self::map_range) before calling
+/// [`activate`](Self::activate) to start using the new page table. To make changes which may
+/// require break-before-make semantics you must first call [`deactivate`](Self::deactivate) to
+/// switch back to a previous static page table, and then `activate` again after making the desired
+/// changes.
+///
+/// # Example
+///
+/// ```
+/// use aarch64_paging::{
+///     idmap::IdMap,
+///     paging::{Attributes, MemoryRegion},
+/// };
+///
+/// const ASID: usize = 1;
+/// const ROOT_LEVEL: usize = 1;
+///
+/// // Create a new page table with identity mapping.
+/// let mut idmap = IdMap::new(ASID, ROOT_LEVEL);
+/// // Map a 2 MiB region of memory as read-write.
+/// idmap.map_range(
+///     &MemoryRegion::new(0x80200000, 0x80400000),
+///     Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::EXECUTE_NEVER,
+/// ).unwrap();
+/// // Set `TTBR0_EL1` to activate the page table.
+/// # #[cfg(target_arch = "aarch64")]
+/// idmap.activate();
+///
+/// // Write something to the memory...
+///
+/// // Restore `TTBR0_EL1` to its earlier value while we modify the page table.
+/// # #[cfg(target_arch = "aarch64")]
+/// idmap.deactivate();
+/// // Now change the mapping to read-only and executable.
+/// idmap.map_range(
+///     &MemoryRegion::new(0x80200000, 0x80400000),
+///     Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::READ_ONLY,
+/// ).unwrap();
+/// # #[cfg(target_arch = "aarch64")]
+/// idmap.activate();
+/// ```
+#[derive(Debug)]
+pub struct IdMap {
+    mapping: Mapping<IdTranslation>,
+}
+
+impl IdMap {
+    /// Creates a new identity-mapping page table with the given ASID and root level.
+    pub fn new(asid: usize, rootlevel: usize) -> Self {
+        Self {
+            mapping: Mapping::new(IdTranslation, asid, rootlevel),
+        }
+    }
+
+    /// Activates the page table by setting `TTBR0_EL1` to point to it, and saves the previous value
+    /// of `TTBR0_EL1` so that it may later be restored by [`deactivate`](Self::deactivate).
+    ///
+    /// Panics if a previous value of `TTBR0_EL1` is already saved and not yet used by a call to
+    /// `deactivate`.
+    #[cfg(target_arch = "aarch64")]
+    pub fn activate(&mut self) {
+        self.mapping.activate()
+    }
+
+    /// Deactivates the page table, by setting `TTBR0_EL1` back to the value it had before
+    /// [`activate`](Self::activate) was called, and invalidating the TLB for this page table's
+    /// configured ASID.
+    ///
+    /// Panics if there is no saved `TTRB0_EL1` value because `activate` has not previously been
+    /// called.
+    #[cfg(target_arch = "aarch64")]
+    pub fn deactivate(&mut self) {
+        self.mapping.deactivate()
+    }
+
+    /// Maps the given range of virtual addresses to the identical physical addresses with the given
+    /// flags.
+    ///
+    /// This should generally only be called while the page table is not active. In particular, any
+    /// change that may require break-before-make per the architecture must be made while the page
+    /// table is inactive. Mapping a previously unmapped memory range may be done while the page
+    /// table is active.
+    pub fn map_range(&mut self, range: &MemoryRegion, flags: Attributes) -> Result<(), MapError> {
+        let pa = IdTranslation::virtual_to_physical(range.start());
+        self.mapping.map_range(range, pa, flags)
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -38,21 +144,21 @@ mod tests {
     #[test]
     fn map_valid() {
         // A single byte at the start of the address space.
-        let mut idmap = IdMap::new(IdTranslation, 1, 1);
+        let mut idmap = IdMap::new(1, 1);
         assert_eq!(
             idmap.map_range(&MemoryRegion::new(0, 1), Attributes::NORMAL),
             Ok(())
         );
 
         // Two pages at the start of the address space.
-        let mut idmap = IdMap::new(IdTranslation, 1, 1);
+        let mut idmap = IdMap::new(1, 1);
         assert_eq!(
             idmap.map_range(&MemoryRegion::new(0, PAGE_SIZE * 2), Attributes::NORMAL),
             Ok(())
         );
 
         // A single byte at the end of the address space.
-        let mut idmap = IdMap::new(IdTranslation, 1, 1);
+        let mut idmap = IdMap::new(1, 1);
         assert_eq!(
             idmap.map_range(
                 &MemoryRegion::new(
@@ -65,7 +171,7 @@ mod tests {
         );
 
         // Two pages, on the boundary between two subtables.
-        let mut idmap = IdMap::new(IdTranslation, 1, 1);
+        let mut idmap = IdMap::new(1, 1);
         assert_eq!(
             idmap.map_range(
                 &MemoryRegion::new(PAGE_SIZE * 1023, PAGE_SIZE * 1025),
@@ -75,7 +181,7 @@ mod tests {
         );
 
         // The entire valid address space.
-        let mut idmap = IdMap::new(IdTranslation, 1, 1);
+        let mut idmap = IdMap::new(1, 1);
         assert_eq!(
             idmap.map_range(
                 &MemoryRegion::new(0, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
@@ -87,7 +193,7 @@ mod tests {
 
     #[test]
     fn map_out_of_range() {
-        let mut idmap = IdMap::new(IdTranslation, 1, 1);
+        let mut idmap = IdMap::new(1, 1);
 
         // One byte, just past the edge of the valid range.
         assert_eq!(

--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -64,6 +64,16 @@ mod tests {
             Ok(())
         );
 
+        // Two pages, on the boundary between two subtables.
+        let mut idmap = IdMap::new(IdTranslation, 1, 1);
+        assert_eq!(
+            idmap.map_range(
+                &MemoryRegion::new(PAGE_SIZE * 1023, PAGE_SIZE * 1025),
+                Attributes::NORMAL
+            ),
+            Ok(())
+        );
+
         // The entire valid address space.
         let mut idmap = IdMap::new(IdTranslation, 1, 1);
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,10 @@
 //!   - EL1
 //!   - 4 KiB pages
 //!
-//! Full support is only provided for identity mapping and linear mapping; for other mapping schemes
-//! the user of the library must implement some functionality themself including an implementation
-//! of the [`Translation`](paging::Translation) trait.
+//! Full support is provided for identity mapping ([`IdMap`](idmap::IdMap)) and linear mapping
+//! ([`LinearMap`](linearmap::LinearMap)). If you want to use a different mapping scheme, you must
+//! provide an implementation of the [`Translation`](paging::Translation) trait and then use
+//! [`Mapping`] directly.
 //!
 //! # Example
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 //! # Example
 //!
 //! ```
+//! # #[cfg(feature = "alloc")] {
 //! use aarch64_paging::{
 //!     idmap::IdMap,
 //!     paging::{Attributes, MemoryRegion},
@@ -34,14 +35,18 @@
 //! // Set `TTBR0_EL1` to activate the page table.
 //! # #[cfg(target_arch = "aarch64")]
 //! idmap.activate();
+//! # }
 //! ```
 
 #![no_std]
 
+#[cfg(feature = "alloc")]
 pub mod idmap;
+#[cfg(feature = "alloc")]
 pub mod linearmap;
 pub mod paging;
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(target_arch = "aarch64")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! ```
 //! use aarch64_paging::{
-//!     idmap::{IdMap, IdTranslation},
+//!     idmap::IdMap,
 //!     paging::{Attributes, MemoryRegion},
 //! };
 //!
@@ -25,7 +25,7 @@
 //! const ROOT_LEVEL: usize = 1;
 //!
 //! // Create a new page table with identity mapping.
-//! let mut idmap = IdMap::new(IdTranslation, ASID, ROOT_LEVEL);
+//! let mut idmap = IdMap::new(ASID, ROOT_LEVEL);
 //! // Map a 2 MiB region of memory as read-only.
 //! idmap.map_range(
 //!     &MemoryRegion::new(0x80200000, 0x80400000),
@@ -47,7 +47,7 @@ extern crate alloc;
 #[cfg(target_arch = "aarch64")]
 use core::arch::asm;
 use core::fmt::{self, Display, Formatter};
-use paging::{Attributes, MemoryRegion, RootTable, Translation, VirtualAddress};
+use paging::{Attributes, MemoryRegion, PhysicalAddress, RootTable, Translation, VirtualAddress};
 
 /// An error attempting to map some range in the page table.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -70,49 +70,13 @@ impl Display for MapError {
     }
 }
 
-/// Manages a level 1 page-table.
+/// Manages a level 1 page table and associated state.
 ///
 /// Mappings should be added with [`map_range`](Self::map_range) before calling
 /// [`activate`](Self::activate) to start using the new page table. To make changes which may
 /// require break-before-make semantics you must first call [`deactivate`](Self::deactivate) to
 /// switch back to a previous static page table, and then `activate` again after making the desired
 /// changes.
-///
-/// # Example
-///
-/// ```
-/// use aarch64_paging::{
-///     idmap::{IdMap, IdTranslation},
-///     paging::{Attributes, MemoryRegion},
-/// };
-///
-/// const ASID: usize = 1;
-/// const ROOT_LEVEL: usize = 1;
-///
-/// // Create a new page table with identity mapping.
-/// let mut idmap = IdMap::new(IdTranslation, ASID, ROOT_LEVEL);
-/// // Map a 2 MiB region of memory as read-write.
-/// idmap.map_range(
-///     &MemoryRegion::new(0x80200000, 0x80400000),
-///     Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::EXECUTE_NEVER,
-/// ).unwrap();
-/// // Set `TTBR0_EL1` to activate the page table.
-/// # #[cfg(target_arch = "aarch64")]
-/// idmap.activate();
-///
-/// // Write something to the memory...
-///
-/// // Restore `TTBR0_EL1` to its earlier value while we modify the page table.
-/// # #[cfg(target_arch = "aarch64")]
-/// idmap.deactivate();
-/// // Now change the mapping to read-only and executable.
-/// idmap.map_range(
-///     &MemoryRegion::new(0x80200000, 0x80400000),
-///     Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::READ_ONLY,
-/// ).unwrap();
-/// # #[cfg(target_arch = "aarch64")]
-/// idmap.activate();
-/// ```
 #[derive(Debug)]
 pub struct Mapping<T: Translation + Clone> {
     root: RootTable<T>,
@@ -183,15 +147,20 @@ impl<T: Translation + Clone> Mapping<T> {
         self.previous_ttbr = None;
     }
 
-    /// Maps the given range of virtual addresses to the identical physical addresses with the given
-    /// flags.
+    /// Maps the given range of virtual addresses to the corresponding range of physical addresses
+    /// starting at `pa`, with the given flags.
     ///
     /// This should generally only be called while the page table is not active. In particular, any
     /// change that may require break-before-make per the architecture must be made while the page
     /// table is inactive. Mapping a previously unmapped memory range may be done while the page
     /// table is active.
-    pub fn map_range(&mut self, range: &MemoryRegion, flags: Attributes) -> Result<(), MapError> {
-        self.root.map_range(range, flags)?;
+    pub fn map_range(
+        &mut self,
+        range: &MemoryRegion,
+        pa: PhysicalAddress,
+        flags: Attributes,
+    ) -> Result<(), MapError> {
+        self.root.map_range(range, pa, flags)?;
         #[cfg(target_arch = "aarch64")]
         unsafe {
             // Safe because this is just a memory barrier.

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -5,9 +5,13 @@
 //! Functionality for managing page tables with linear mapping.
 
 use crate::{
-    paging::{PhysicalAddress, Translation, VirtualAddress},
+    paging::{
+        deallocate, Attributes, MemoryRegion, PageTable, PhysicalAddress, Translation,
+        VirtualAddress,
+    },
     MapError, Mapping,
 };
+use core::ptr::NonNull;
 
 /// Linear mapping, where every virtual address is either unmapped or mapped to an IPA with a fixed
 /// offset.
@@ -25,13 +29,29 @@ impl LinearTranslation {
     }
 }
 
-impl Translation for LinearTranslation {
+impl LinearTranslation {
     fn virtual_to_physical(&self, va: VirtualAddress) -> Result<PhysicalAddress, MapError> {
         if let Some(pa) = checked_add_signed(va.0, self.offset) {
             Ok(PhysicalAddress(pa))
         } else {
             Err(MapError::InvalidVirtualAddress(va))
         }
+    }
+}
+
+impl Translation for LinearTranslation {
+    fn allocate_table(&self) -> (NonNull<PageTable>, PhysicalAddress) {
+        let table = PageTable::new();
+        let va = VirtualAddress::from(table.as_ptr());
+
+        let pa = self.virtual_to_physical(va).expect(
+            "Allocated subtable with virtual address which doesn't correspond to any physical address."
+        );
+        (table, pa)
+    }
+
+    unsafe fn deallocate_table(&self, page_table: NonNull<PageTable>) {
+        deallocate(page_table);
     }
 
     fn physical_to_virtual(&self, pa: PhysicalAddress) -> VirtualAddress {
@@ -53,7 +73,58 @@ fn checked_add_signed(a: usize, b: isize) -> Option<usize> {
     }
 }
 
-pub type LinearMap = Mapping<LinearTranslation>;
+/// Manages a level 1 page table using linear mapping, where every virtual address is either
+/// unmapped or mapped to an IPA with a fixed offset.
+#[derive(Debug)]
+pub struct LinearMap {
+    mapping: Mapping<LinearTranslation>,
+}
+
+impl LinearMap {
+    /// Creates a new identity-mapping page table with the given ASID and root level.
+    pub fn new(asid: usize, rootlevel: usize, offset: isize) -> Self {
+        Self {
+            mapping: Mapping::new(LinearTranslation::new(offset), asid, rootlevel),
+        }
+    }
+
+    /// Activates the page table by setting `TTBR0_EL1` to point to it, and saves the previous value
+    /// of `TTBR0_EL1` so that it may later be restored by [`deactivate`](Self::deactivate).
+    ///
+    /// Panics if a previous value of `TTBR0_EL1` is already saved and not yet used by a call to
+    /// `deactivate`.
+    #[cfg(target_arch = "aarch64")]
+    pub fn activate(&mut self) {
+        self.mapping.activate()
+    }
+
+    /// Deactivates the page table, by setting `TTBR0_EL1` back to the value it had before
+    /// [`activate`](Self::activate) was called, and invalidating the TLB for this page table's
+    /// configured ASID.
+    ///
+    /// Panics if there is no saved `TTRB0_EL1` value because `activate` has not previously been
+    /// called.
+    #[cfg(target_arch = "aarch64")]
+    pub fn deactivate(&mut self) {
+        self.mapping.deactivate()
+    }
+
+    /// Maps the given range of virtual addresses to the corresponding physical addresses with the
+    /// given flags.
+    ///
+    /// This should generally only be called while the page table is not active. In particular, any
+    /// change that may require break-before-make per the architecture must be made while the page
+    /// table is inactive. Mapping a previously unmapped memory range may be done while the page
+    /// table is active.
+    pub fn map_range(&mut self, range: &MemoryRegion, flags: Attributes) -> Result<(), MapError> {
+        let pa = self
+            .mapping
+            .root
+            .translation()
+            .virtual_to_physical(range.start())?;
+        self.mapping.map_range(range, pa, flags)
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -68,21 +139,21 @@ mod tests {
     #[test]
     fn map_valid() {
         // A single byte at the start of the address space.
-        let mut pagetable = LinearMap::new(LinearTranslation::new(4096), 1, 1);
+        let mut pagetable = LinearMap::new(1, 1, 4096);
         assert_eq!(
             pagetable.map_range(&MemoryRegion::new(0, 1), Attributes::NORMAL),
             Ok(())
         );
 
         // Two pages at the start of the address space.
-        let mut pagetable = LinearMap::new(LinearTranslation::new(4096), 1, 1);
+        let mut pagetable = LinearMap::new(1, 1, 4096);
         assert_eq!(
             pagetable.map_range(&MemoryRegion::new(0, PAGE_SIZE * 2), Attributes::NORMAL),
             Ok(())
         );
 
         // A single byte at the end of the address space.
-        let mut pagetable = LinearMap::new(LinearTranslation::new(4096), 1, 1);
+        let mut pagetable = LinearMap::new(1, 1, 4096);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(
@@ -95,7 +166,7 @@ mod tests {
         );
 
         // The entire valid address space.
-        let mut pagetable = LinearMap::new(LinearTranslation::new(4096), 1, 1);
+        let mut pagetable = LinearMap::new(1, 1, 4096);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
@@ -108,7 +179,7 @@ mod tests {
     #[test]
     fn map_valid_negative_offset() {
         // A single byte which maps to IPA 0.
-        let mut pagetable = LinearMap::new(LinearTranslation::new(-(PAGE_SIZE as isize)), 1, 1);
+        let mut pagetable = LinearMap::new(1, 1, -(PAGE_SIZE as isize));
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(PAGE_SIZE, PAGE_SIZE + 1),
@@ -118,7 +189,7 @@ mod tests {
         );
 
         // Two pages at the start of the address space.
-        let mut pagetable = LinearMap::new(LinearTranslation::new(-(PAGE_SIZE as isize)), 1, 1);
+        let mut pagetable = LinearMap::new(1, 1, -(PAGE_SIZE as isize));
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(PAGE_SIZE, PAGE_SIZE * 3),
@@ -128,7 +199,7 @@ mod tests {
         );
 
         // A single byte at the end of the address space.
-        let mut pagetable = LinearMap::new(LinearTranslation::new(-(PAGE_SIZE as isize)), 1, 1);
+        let mut pagetable = LinearMap::new(1, 1, -(PAGE_SIZE as isize));
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(
@@ -141,7 +212,7 @@ mod tests {
         );
 
         // The entire valid address space.
-        let mut pagetable = LinearMap::new(LinearTranslation::new(-(PAGE_SIZE as isize)), 1, 1);
+        let mut pagetable = LinearMap::new(1, 1, -(PAGE_SIZE as isize));
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(PAGE_SIZE, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
@@ -153,7 +224,7 @@ mod tests {
 
     #[test]
     fn map_out_of_range() {
-        let mut pagetable = LinearMap::new(LinearTranslation::new(4096), 1, 1);
+        let mut pagetable = LinearMap::new(1, 1, 4096);
 
         // One byte, just past the edge of the valid range.
         assert_eq!(
@@ -183,7 +254,7 @@ mod tests {
 
     #[test]
     fn map_invalid_offset() {
-        let mut pagetable = LinearMap::new(LinearTranslation::new(-4096), 1, 1);
+        let mut pagetable = LinearMap::new(1, 1, -4096);
 
         // One byte, with an offset which would map it to a negative IPA.
         assert_eq!(

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -6,9 +6,9 @@
 //! addresses are mapped.
 
 use crate::MapError;
-use alloc::alloc::{alloc_zeroed, dealloc, handle_alloc_error};
+#[cfg(feature = "alloc")]
+use alloc::alloc::{alloc_zeroed, dealloc, handle_alloc_error, Layout};
 use bitflags::bitflags;
-use core::alloc::Layout;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::ops::{Add, Range, Sub};
 use core::ptr::NonNull;
@@ -474,6 +474,7 @@ pub struct PageTable {
 impl PageTable {
     /// Allocates a new zeroed, appropriately-aligned pagetable on the heap using the global
     /// allocator and returns a pointer to it.
+    #[cfg(feature = "alloc")]
     pub fn new() -> NonNull<Self> {
         // Safe because the pointer has been allocated with the appropriate layout by the global
         // allocator, and the memory is zeroed which is valid initialisation for a PageTable.
@@ -562,6 +563,7 @@ impl Debug for Descriptor {
 /// # Safety
 ///
 /// It must be valid to initialise the type `T` by simply zeroing its memory.
+#[cfg(feature = "alloc")]
 unsafe fn allocate_zeroed<T>() -> NonNull<T> {
     let layout = Layout::new::<T>();
     // Safe because we know the layout has non-zero size.
@@ -579,6 +581,7 @@ unsafe fn allocate_zeroed<T>() -> NonNull<T> {
 ///
 /// The memory must have been allocated by the global allocator, with the layout for `T`, and not
 /// yet deallocated.
+#[cfg(feature = "alloc")]
 pub(crate) unsafe fn deallocate<T>(ptr: NonNull<T>) {
     let layout = Layout::new::<T>();
     dealloc(ptr.as_ptr() as *mut u8, layout);
@@ -595,8 +598,10 @@ const fn align_up(value: usize, alignment: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "alloc")]
     use alloc::{format, string::ToString};
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn display_memory_region() {
         let region = MemoryRegion::new(0x1234, 0x56789);


### PR DESCRIPTION
This PR makes the `Translation` trait responsible for allocating page tables. This should help make it possible to use more complex mapping schemes, and to construct page tables in a different context to where they are used. This also allows allows us to make the `alloc` dependency optional (as it's only used by `IdMap` and `LinearMap`, not the core pagetable code).

TODO:

- [x] What about freeing subtables? Currently this assumes they are allocated by the global allocator, as it uses that to free them.