### PR TITLE
Fix bug with block mappings for non-identity map page tables

### DIFF
--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -154,7 +154,7 @@ impl LinearMap {
 mod tests {
     use super::*;
     use crate::{
-        paging::{Attributes, MemoryRegion, PAGE_SIZE},
+        paging::{Attributes, MemoryRegion, BITS_PER_LEVEL, PAGE_SIZE},
         MapError,
     };
 
@@ -189,8 +189,10 @@ mod tests {
             Ok(())
         );
 
-        // The entire valid address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096);
+        // The entire valid address space. Use an offset that is a multiple of the level 2 block
+        // size to avoid mapping everything as pages as that is really slow.
+        const LEVEL_2_BLOCK_SIZE: usize = PAGE_SIZE << BITS_PER_LEVEL;
+        let mut pagetable = LinearMap::new(1, 1, LEVEL_2_BLOCK_SIZE as isize);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
@@ -235,11 +237,13 @@ mod tests {
             Ok(())
         );
 
-        // The entire valid address space.
-        let mut pagetable = LinearMap::new(1, 1, -(PAGE_SIZE as isize));
+        // The entire valid address space. Use an offset that is a multiple of the level 2 block
+        // size to avoid mapping everything as pages as that is really slow.
+        const LEVEL_2_BLOCK_SIZE: usize = PAGE_SIZE << BITS_PER_LEVEL;
+        let mut pagetable = LinearMap::new(1, 1, -(LEVEL_2_BLOCK_SIZE as isize));
         assert_eq!(
             pagetable.map_range(
-                &MemoryRegion::new(PAGE_SIZE, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
+                &MemoryRegion::new(LEVEL_2_BLOCK_SIZE, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
                 Attributes::NORMAL
             ),
             Ok(())

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -303,4 +303,27 @@ mod tests {
             Err(MapError::InvalidVirtualAddress(va))
         )
     }
+
+    #[test]
+    fn block_mapping() {
+        // Test that block mapping is used when the PA is appropriately aligned...
+        let mut pagetable = LinearMap::new(1, 1, 1 << 30);
+        pagetable
+            .map_range(&MemoryRegion::new(0, 1 << 30), Attributes::NORMAL)
+            .unwrap();
+        assert_eq!(
+            pagetable.mapping.root.mapping_level(VirtualAddress(0)),
+            Some(1)
+        );
+
+        // ...but not when it is not.
+        let mut pagetable = LinearMap::new(1, 1, 1 << 29);
+        pagetable
+            .map_range(&MemoryRegion::new(0, 1 << 30), Attributes::NORMAL)
+            .unwrap();
+        assert_eq!(
+            pagetable.mapping.root.mapping_level(VirtualAddress(0)),
+            Some(2)
+        );
+    }
 }

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -8,8 +8,8 @@
 
 use crate::{
     paging::{
-        deallocate, Attributes, MemoryRegion, PageTable, PhysicalAddress, Translation,
-        VirtualAddress,
+        deallocate, is_aligned, Attributes, MemoryRegion, PageTable, PhysicalAddress, Translation,
+        VirtualAddress, PAGE_SIZE,
     },
     MapError, Mapping,
 };
@@ -26,7 +26,15 @@ pub struct LinearTranslation {
 impl LinearTranslation {
     /// Constructs a new linear translation, which will map a virtual address `va` to the
     /// (intermediate) physical address `va + offset`.
+    ///
+    /// The `offset` must be a multiple of [`PAGE_SIZE`]; if not this will panic.
     pub fn new(offset: isize) -> Self {
+        if !is_aligned(offset.unsigned_abs(), PAGE_SIZE) {
+            panic!(
+                "Invalid offset {}, must be a multiple of page size {}.",
+                offset, PAGE_SIZE,
+            );
+        }
         Self { offset }
     }
 }
@@ -98,6 +106,8 @@ impl LinearMap {
     ///
     /// This will map any virtual address `va` which is added to the table to the physical address
     /// `va + offset`.
+    ///
+    /// The `offset` must be a multiple of [`PAGE_SIZE`]; if not this will panic.
     pub fn new(asid: usize, rootlevel: usize, offset: isize) -> Self {
         Self {
             mapping: Mapping::new(LinearTranslation::new(offset), asid, rootlevel),

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -624,7 +624,7 @@ const fn align_up(value: usize, alignment: usize) -> usize {
     ((value - 1) | (alignment - 1)) + 1
 }
 
-const fn is_aligned(value: usize, alignment: usize) -> bool {
+pub(crate) const fn is_aligned(value: usize, alignment: usize) -> bool {
     value & (alignment - 1) == 0
 }
 

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -243,6 +243,15 @@ impl<T: Translation + Clone> RootTable<T> {
     pub fn translation(&self) -> &T {
         &self.table.translation
     }
+
+    /// Returns the level of mapping used for the given virtual address:
+    /// - `None` if it is unmapped
+    /// - `Some(LEAF_LEVEL)` if it is mapped as a single page
+    /// - `Some(level)` if it is mapped as a block at `level`
+    #[cfg(test)]
+    pub(crate) fn mapping_level(&self, va: VirtualAddress) -> Option<usize> {
+        self.table.mapping_level(va)
+    }
 }
 
 impl<T: Translation + Clone> Drop for RootTable<T> {
@@ -338,6 +347,18 @@ impl<T: Translation + Clone> PageTableWithLevel<T> {
         )
     }
 
+    /// Returns a  reference to the descriptor corresponding to a given virtual address.
+    #[cfg(test)]
+    fn get_entry(&self, va: VirtualAddress) -> &Descriptor {
+        let shift = PAGE_SHIFT + (LEAF_LEVEL - self.level) * BITS_PER_LEVEL;
+        let index = (va.0 >> shift) % (1 << BITS_PER_LEVEL);
+        // Safe because we know that the pointer is properly aligned, dereferenced and initialised,
+        // and nothing else can access the page table while we hold a mutable reference to the
+        // PageTableWithLevel (assuming it is not currently active).
+        let table = unsafe { self.table.as_ref() };
+        &table.entries[index]
+    }
+
     /// Returns a mutable reference to the descriptor corresponding to a given virtual address.
     fn get_entry_mut(&mut self, va: VirtualAddress) -> &mut Descriptor {
         let shift = PAGE_SHIFT + (LEAF_LEVEL - self.level) * BITS_PER_LEVEL;
@@ -360,6 +381,7 @@ impl<T: Translation + Clone> PageTableWithLevel<T> {
     fn map_range(&mut self, range: &MemoryRegion, mut pa: PhysicalAddress, flags: Attributes) {
         let translation = self.translation.clone();
         let level = self.level;
+        let granularity = granularity_at_level(level);
 
         for chunk in range.split(level) {
             let entry = self.get_entry_mut(chunk.0.start);
@@ -367,7 +389,10 @@ impl<T: Translation + Clone> PageTableWithLevel<T> {
             if level == LEAF_LEVEL {
                 // Put down a page mapping.
                 entry.set(pa, flags | Attributes::ACCESSED | Attributes::TABLE_OR_PAGE);
-            } else if chunk.is_block(level) && !entry.is_table_or_page() {
+            } else if chunk.is_block(level)
+                && !entry.is_table_or_page()
+                && is_aligned(pa.0, granularity)
+            {
                 // Rather than leak the entire subhierarchy, only put down
                 // a block mapping if the region is not already covered by
                 // a table mapping.
@@ -379,7 +404,6 @@ impl<T: Translation + Clone> PageTableWithLevel<T> {
                     let old = *entry;
                     let (mut subtable, subtable_pa) = Self::new(translation.clone(), level + 1);
                     if let (Some(old_flags), Some(old_pa)) = (old.flags(), old.output_address()) {
-                        let granularity = granularity_at_level(level);
                         // Old was a valid block entry, so we need to split it.
                         // Recreate the entire block in the newly added table.
                         let a = align_down(chunk.0.start.0, granularity);
@@ -441,6 +465,24 @@ impl<T: Translation + Clone> PageTableWithLevel<T> {
         unsafe {
             // Actually free the memory used by the `PageTable`.
             self.translation.deallocate_table(self.table);
+        }
+    }
+
+    /// Returns the level of mapping used for the given virtual address:
+    /// - `None` if it is unmapped
+    /// - `Some(LEAF_LEVEL)` if it is mapped as a single page
+    /// - `Some(level)` if it is mapped as a block at `level`
+    #[cfg(test)]
+    fn mapping_level(&self, va: VirtualAddress) -> Option<usize> {
+        let entry = self.get_entry(va);
+        if let Some(subtable) = entry.subtable(&self.translation, self.level) {
+            subtable.mapping_level(va)
+        } else {
+            if entry.is_valid() {
+                Some(self.level)
+            } else {
+                None
+            }
         }
     }
 }
@@ -580,6 +622,10 @@ const fn align_down(value: usize, alignment: usize) -> usize {
 
 const fn align_up(value: usize, alignment: usize) -> usize {
     ((value - 1) | (alignment - 1)) + 1
+}
+
+const fn is_aligned(value: usize, alignment: usize) -> bool {
+    value & (alignment - 1) == 0
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`LinearMap` and any other mapping which may have different alignment of virtual and physical addresses was incorrectly using block mappings in cases where the physical address didn't have the required alignment. The architecture requires that we only make block mappings when the physical addresses are aligned to the size of the block, so this fixes the code to do that, and adds a test.