### PR TITLE
Update to latest version of bitflags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Updated `bitflags` to 2.0.2, which changes the API of `Attributes` a bit.
+
 ### New features
 
 - Added `modify_range` method to `IdMap`, `LinearMap` and `Mapping` to update details of a mapped

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["arm", "aarch64", "cortex-a", "vmsa", "pagetable"]
 categories = ["embedded", "no-std", "hardware-support"]
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.0.2"
 
 [features]
 default = ["alloc"]

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -388,6 +388,7 @@ impl Iterator for ChunkedIterator<'_> {
 
 bitflags! {
     /// Attribute bits for a mapping in a page table.
+    #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct Attributes: usize {
         const VALID         = 1 << 0;
         const TABLE_OR_PAGE = 1 << 1;


### PR DESCRIPTION
This is a breaking change because it changes the API of `Attributes` which is part of the public API.