### PR TITLE
Allow mapping invalid leaf entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Breaking changes
 
 - Updated `bitflags` to 2.0.2, which changes the API of `Attributes` a bit.
+- Updated `map_range` method to support mapping leaf page table entries without the `VALID` flag.
+  `Attributes::VALID` is no longer implicitly set when mapping leaf page table entries.
 
 ### New features
 

--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -130,7 +130,8 @@ impl IdMap {
     /// This should generally only be called while the page table is not active. In particular, any
     /// change that may require break-before-make per the architecture must be made while the page
     /// table is inactive. Mapping a previously unmapped memory range may be done while the page
-    /// table is active.
+    /// table is active. This function writes block and page entries, but only maps them if `flags`
+    /// contains `Attributes::VALID`, otherwise the entries remain invalid.
     ///
     /// # Errors
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,8 @@ impl<T: Translation + Clone> Mapping<T> {
     /// This should generally only be called while the page table is not active. In particular, any
     /// change that may require break-before-make per the architecture must be made while the page
     /// table is inactive. Mapping a previously unmapped memory range may be done while the page
-    /// table is active.
+    /// table is active. This function writes block and page entries, but only maps them if `flags`
+    /// contains `Attributes::VALID`, otherwise the entries remain invalid.
     ///
     /// # Errors
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! // Map a 2 MiB region of memory as read-only.
 //! idmap.map_range(
 //!     &MemoryRegion::new(0x80200000, 0x80400000),
-//!     Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::READ_ONLY,
+//!     Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::READ_ONLY | Attributes::VALID,
 //! ).unwrap();
 //! // Set `TTBR0_EL1` to activate the page table.
 //! # #[cfg(target_arch = "aarch64")]

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -200,14 +200,20 @@ mod tests {
         // A single byte at the start of the address space.
         let mut pagetable = LinearMap::new(1, 1, 4096, VaRange::Lower);
         assert_eq!(
-            pagetable.map_range(&MemoryRegion::new(0, 1), Attributes::NORMAL),
+            pagetable.map_range(
+                &MemoryRegion::new(0, 1),
+                Attributes::NORMAL | Attributes::VALID
+            ),
             Ok(())
         );
 
         // Two pages at the start of the address space.
         let mut pagetable = LinearMap::new(1, 1, 4096, VaRange::Lower);
         assert_eq!(
-            pagetable.map_range(&MemoryRegion::new(0, PAGE_SIZE * 2), Attributes::NORMAL),
+            pagetable.map_range(
+                &MemoryRegion::new(0, PAGE_SIZE * 2),
+                Attributes::NORMAL | Attributes::VALID
+            ),
             Ok(())
         );
 
@@ -219,7 +225,7 @@ mod tests {
                     MAX_ADDRESS_FOR_ROOT_LEVEL_1 - 1,
                     MAX_ADDRESS_FOR_ROOT_LEVEL_1
                 ),
-                Attributes::NORMAL
+                Attributes::NORMAL | Attributes::VALID
             ),
             Ok(())
         );
@@ -231,7 +237,7 @@ mod tests {
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
-                Attributes::NORMAL
+                Attributes::NORMAL | Attributes::VALID
             ),
             Ok(())
         );
@@ -244,7 +250,7 @@ mod tests {
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(PAGE_SIZE, PAGE_SIZE + 1),
-                Attributes::NORMAL
+                Attributes::NORMAL | Attributes::VALID
             ),
             Ok(())
         );
@@ -254,7 +260,7 @@ mod tests {
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(PAGE_SIZE, PAGE_SIZE * 3),
-                Attributes::NORMAL
+                Attributes::NORMAL | Attributes::VALID
             ),
             Ok(())
         );
@@ -267,7 +273,7 @@ mod tests {
                     MAX_ADDRESS_FOR_ROOT_LEVEL_1 - 1,
                     MAX_ADDRESS_FOR_ROOT_LEVEL_1
                 ),
-                Attributes::NORMAL
+                Attributes::NORMAL | Attributes::VALID
             ),
             Ok(())
         );
@@ -279,7 +285,7 @@ mod tests {
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(LEVEL_2_BLOCK_SIZE, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
-                Attributes::NORMAL
+                Attributes::NORMAL | Attributes::VALID
             ),
             Ok(())
         );
@@ -296,7 +302,7 @@ mod tests {
                     MAX_ADDRESS_FOR_ROOT_LEVEL_1,
                     MAX_ADDRESS_FOR_ROOT_LEVEL_1 + 1,
                 ),
-                Attributes::NORMAL
+                Attributes::NORMAL | Attributes::VALID
             ),
             Err(MapError::AddressRange(VirtualAddress(
                 MAX_ADDRESS_FOR_ROOT_LEVEL_1 + PAGE_SIZE
@@ -307,7 +313,7 @@ mod tests {
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, MAX_ADDRESS_FOR_ROOT_LEVEL_1 + 1),
-                Attributes::NORMAL
+                Attributes::NORMAL | Attributes::VALID
             ),
             Err(MapError::AddressRange(VirtualAddress(
                 MAX_ADDRESS_FOR_ROOT_LEVEL_1 + PAGE_SIZE
@@ -419,7 +425,10 @@ mod tests {
         // Test that block mapping is used when the PA is appropriately aligned...
         let mut pagetable = LinearMap::new(1, 1, 1 << 30, VaRange::Lower);
         pagetable
-            .map_range(&MemoryRegion::new(0, 1 << 30), Attributes::NORMAL)
+            .map_range(
+                &MemoryRegion::new(0, 1 << 30),
+                Attributes::NORMAL | Attributes::VALID,
+            )
             .unwrap();
         assert_eq!(
             pagetable.mapping.root.mapping_level(VirtualAddress(0)),
@@ -429,7 +438,10 @@ mod tests {
         // ...but not when it is not.
         let mut pagetable = LinearMap::new(1, 1, 1 << 29, VaRange::Lower);
         pagetable
-            .map_range(&MemoryRegion::new(0, 1 << 30), Attributes::NORMAL)
+            .map_range(
+                &MemoryRegion::new(0, 1 << 30),
+                Attributes::NORMAL | Attributes::VALID,
+            )
             .unwrap();
         assert_eq!(
             pagetable.mapping.root.mapping_level(VirtualAddress(0)),
@@ -477,6 +489,35 @@ mod tests {
             }
             Ok(())
         })
+        .unwrap();
+    }
+
+    #[test]
+    fn breakup_invalid_block() {
+        const BLOCK_RANGE: usize = 0x200000;
+
+        let mut lmap = LinearMap::new(1, 1, 0x1000, VaRange::Lower);
+        lmap.map_range(
+            &MemoryRegion::new(0, BLOCK_RANGE),
+            Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::SWFLAG_0,
+        )
+        .unwrap();
+        lmap.map_range(
+            &MemoryRegion::new(0, PAGE_SIZE),
+            Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::VALID,
+        )
+        .unwrap();
+        lmap.modify_range(
+            &MemoryRegion::new(0, BLOCK_RANGE),
+            &|range, entry, level| {
+                if level == 3 {
+                    let has_swflag = entry.flags().unwrap().contains(Attributes::SWFLAG_0);
+                    let is_first_page = range.start().0 == 0usize;
+                    assert!(has_swflag != is_first_page);
+                }
+                Ok(())
+            },
+        )
         .unwrap();
     }
 }

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -139,7 +139,8 @@ impl LinearMap {
     /// This should generally only be called while the page table is not active. In particular, any
     /// change that may require break-before-make per the architecture must be made while the page
     /// table is inactive. Mapping a previously unmapped memory range may be done while the page
-    /// table is active.
+    /// table is active. This function writes block and page entries, but only maps them if `flags`
+    /// contains `Attributes::VALID`, otherwise the entries remain invalid.
     ///
     /// # Errors
     ///

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -538,6 +538,7 @@ impl<T: Translation> PageTableWithLevel<T> {
         translation: &T,
         indentation: usize,
     ) -> Result<(), fmt::Error> {
+        const WIDTH: usize = 3;
         // Safe because we know that the pointer is aligned, initialised and dereferencable, and the
         // PageTable won't be mutated while we are using it.
         let table = unsafe { self.table.as_ref() };
@@ -550,12 +551,16 @@ impl<T: Translation> PageTableWithLevel<T> {
                     i += 1;
                 }
                 if i - 1 == first_zero {
-                    writeln!(f, "{:indentation$}{}: 0", "", first_zero)?;
+                    writeln!(f, "{:indentation$}{: <WIDTH$}: 0", "", first_zero)?;
                 } else {
-                    writeln!(f, "{:indentation$}{}-{}: 0", "", first_zero, i - 1)?;
+                    writeln!(f, "{:indentation$}{: <WIDTH$}-{}: 0", "", first_zero, i - 1)?;
                 }
             } else {
-                writeln!(f, "{:indentation$}{}: {:?}", "", i, table.entries[i])?;
+                writeln!(
+                    f,
+                    "{:indentation$}{: <WIDTH$}: {:?}",
+                    "", i, table.entries[i],
+                )?;
                 if let Some(subtable) = table.entries[i].subtable(translation, self.level) {
                     subtable.fmt_indented(f, translation, indentation + 2)?;
                 }
@@ -708,8 +713,10 @@ impl Descriptor {
 impl Debug for Descriptor {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         write!(f, "{:#016x}", self.0)?;
-        if let (Some(flags), Some(address)) = (self.flags(), self.output_address()) {
-            write!(f, " ({}, {:?})", address, flags)?;
+        if self.is_valid() {
+            if let Some(flags) = self.flags() {
+                write!(f, " ({}, {:?})", self.output_address(), flags)?;
+            }
         }
         Ok(())
     }

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -838,18 +838,19 @@ mod tests {
 
     #[test]
     fn set_descriptor() {
+        const PHYSICAL_ADDRESS: usize = 0x12340000;
         let mut desc = Descriptor(0usize);
         assert!(!desc.is_valid());
         desc.set(
-            PhysicalAddress(0x12340000),
-            Attributes::TABLE_OR_PAGE | Attributes::USER | Attributes::SWFLAG_1,
+            PhysicalAddress(PHYSICAL_ADDRESS),
+            Attributes::TABLE_OR_PAGE | Attributes::USER | Attributes::SWFLAG_1 | Attributes::VALID,
         );
         assert!(desc.is_valid());
         assert_eq!(
             desc.flags().unwrap(),
             Attributes::TABLE_OR_PAGE | Attributes::USER | Attributes::SWFLAG_1 | Attributes::VALID
         );
-        assert_eq!(desc.output_address().unwrap(), PhysicalAddress(0x12340000));
+        assert_eq!(desc.output_address(), PhysicalAddress(PHYSICAL_ADDRESS));
     }
 
     #[test]


### PR DESCRIPTION
Break up invalid block entries into a new subtable when a new range smaller than the block is mapped. Also, allow mapping block and page entries without a VALID bit.