### PR TITLE
Mark page tables as Send

### DIFF
--- a/src/paging.rs
+++ b/src/paging.rs
@@ -424,6 +424,10 @@ struct PageTableWithLevel<T: Translation> {
     _translation: PhantomData<T>,
 }
 
+// SAFETY: The underlying PageTable is process-wide and can be safely accessed from any thread
+// with appropriate synchronization. This type manages ownership for the raw pointer.
+unsafe impl <T: Translation + Send> Send for PageTableWithLevel<T> {}
+
 impl<T: Translation> PageTableWithLevel<T> {
     /// Allocates a new, zeroed, appropriately-aligned page table with the given translation,
     /// returning both a pointer to it and its physical address.


### PR DESCRIPTION
PageTableWithLevel is not automatically Send because of the contained NonNull.

Explicitly implement the trait since it is in face safe (which then means all the related types up to and including Mapping are automatically Send).

This allows them to be accessed from multiple threads with appropriate synchronization.

We do not, of course, mark any of these types as Sync.