### PR TITLE
Implement walk_range for traversing page tables

### DIFF
--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -8,8 +8,8 @@
 
 use crate::{
     paging::{
-        deallocate, Attributes, MemoryRegion, PageTable, PhysicalAddress, PteUpdater, Translation,
-        VaRange, VirtualAddress,
+        deallocate, Attributes, Descriptor, MemoryRegion, PageTable, PhysicalAddress, PteUpdater,
+        Translation, VaRange, VirtualAddress,
     },
     MapError, Mapping,
 };
@@ -164,6 +164,24 @@ impl IdMap {
     /// largest virtual address covered by the page table given its root level.
     pub fn modify_range(&mut self, range: &MemoryRegion, f: &PteUpdater) -> Result<(), MapError> {
         self.mapping.modify_range(range, f)
+    }
+
+    /// Applies the provided function to a number of PTEs corresponding to a given memory range.
+    ///
+    /// The virtual address range passed to the callback function may be expanded compared to the
+    /// `range` parameter, due to alignment to block boundaries.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MapError::RegionBackwards`] if the range is backwards.
+    ///
+    /// Returns [`MapError::AddressRange`] if the largest address in the `range` is greater than the
+    /// largest virtual address covered by the page table given its root level.
+    pub fn walk_range<F>(&self, range: &MemoryRegion, f: &mut F) -> Result<(), MapError>
+    where
+        F: FnMut(&MemoryRegion, &Descriptor, usize),
+    {
+        self.mapping.walk_range(range, f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,24 @@ impl<T: Translation + Clone> Mapping<T> {
         }
         Ok(())
     }
+
+    /// Applies the provided function to a number of PTEs corresponding to a given memory range.
+    ///
+    /// The virtual address range passed to the callback function may be expanded compared to the
+    /// `range` parameter, due to alignment to block boundaries.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MapError::RegionBackwards`] if the range is backwards.
+    ///
+    /// Returns [`MapError::AddressRange`] if the largest address in the `range` is greater than the
+    /// largest virtual address covered by the page table given its root level.
+    pub fn walk_range<F>(&self, range: &MemoryRegion, f: &mut F) -> Result<(), MapError>
+    where
+        F: FnMut(&MemoryRegion, &Descriptor, usize),
+    {
+        self.root.walk_range(range, f)
+    }
 }
 
 impl<T: Translation + Clone> Drop for Mapping<T> {

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -8,8 +8,8 @@
 
 use crate::{
     paging::{
-        deallocate, is_aligned, Attributes, MemoryRegion, PageTable, PhysicalAddress, PteUpdater,
-        Translation, VaRange, VirtualAddress, PAGE_SIZE,
+        deallocate, is_aligned, Attributes, Descriptor, MemoryRegion, PageTable, PhysicalAddress,
+        PteUpdater, Translation, VaRange, VirtualAddress, PAGE_SIZE,
     },
     MapError, Mapping,
 };
@@ -180,6 +180,24 @@ impl LinearMap {
     /// largest virtual address covered by the page table given its root level.
     pub fn modify_range(&mut self, range: &MemoryRegion, f: &PteUpdater) -> Result<(), MapError> {
         self.mapping.modify_range(range, f)
+    }
+
+    /// Applies the provided function to a number of PTEs corresponding to a given memory range.
+    ///
+    /// The virtual address range passed to the updater function may be expanded compared to the
+    /// `range` parameter, due to alignment to block boundaries.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MapError::RegionBackwards`] if the range is backwards.
+    ///
+    /// Returns [`MapError::AddressRange`] if the largest address in the `range` is greater than the
+    /// largest virtual address covered by the page table given its root level.
+    pub fn walk_range<F>(&self, range: &MemoryRegion, f: &mut F) -> Result<(), MapError>
+    where
+        F: FnMut(&MemoryRegion, &Descriptor, usize),
+    {
+        self.mapping.walk_range(range, f)
     }
 }
 


### PR DESCRIPTION
Unlike modify_range(), this uses a bound on the type F defining the prototype of the callback function. This is necessary because walking the page tables using an immutable reference to the Mapping object requires a mutable closure, and this cannot be achieved using a dynamic function type like PteUpdater.