### PR TITLE
Mark activate and deactivate methods as unsafe.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
   function and prevent them from being converted into table descriptors
   inadvertently.
 - Added rigid break-before-make (BBM) checks to `map_range` and `modify_range`.
-- Added `constraints` argument to `map_range()`
+- Added `constraints` argument to `map_range()`.
+- Marked `activate` and `deactivate` methods as unsafe.
 
 ### New features
 

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -119,7 +119,14 @@ impl LinearMap {
     /// `deactivate`.
     ///
     /// In test builds or builds that do not target aarch64, the `TTBRn_EL1` access is omitted.
-    pub fn activate(&mut self) {
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the page table doesn't unmap any memory which the program is
+    /// using, or introduce aliases which break Rust's aliasing rules. The page table must not be
+    /// dropped as long as its mappings are required, as it will automatically be deactivated when
+    /// it is dropped.
+    pub unsafe fn activate(&mut self) {
         self.mapping.activate()
     }
 
@@ -131,7 +138,12 @@ impl LinearMap {
     /// called.
     ///
     /// In test builds or builds that do not target aarch64, the `TTBRn_EL1` access is omitted.
-    pub fn deactivate(&mut self) {
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the previous page table which this is switching back to doesn't
+    /// unmap any memory which the program is using.
+    pub unsafe fn deactivate(&mut self) {
         self.mapping.deactivate()
     }
 


### PR DESCRIPTION
They change memory mappings, so the caller must ensure that the program is still able to run correctly with the new mappings.