### PR TITLE
Fix inaccurate documentation

### DIFF
--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -248,8 +248,8 @@ impl IdMap {
     ///
     /// The callback function receives the following arguments:
     ///
-    /// - The full virtual address range mapped by each visited page table descriptor, which may
-    ///   exceed the original range passed to `walk_range`, due to alignment to block boundaries.
+    /// - The range covered by the current step in the walk. This is always a subrange of `range`
+    ///   even when the descriptor covers a region that exceeds it.
     /// - The page table descriptor itself.
     /// - The level of a translation table the descriptor belongs to.
     ///

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -260,8 +260,8 @@ impl LinearMap {
     ///
     /// The callback function receives the following arguments:
     ///
-    /// - The full virtual address range mapped by each visited page table descriptor, which may
-    ///   exceed the original range passed to `walk_range`, due to alignment to block boundaries.
+    /// - The range covered by the current step in the walk. This is always a subrange of `range`
+    ///   even when the descriptor covers a region that exceeds it.
     /// - The page table descriptor itself.
     /// - The level of a translation table the descriptor belongs to.
     ///

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -345,8 +345,8 @@ impl<T: Translation> RootTable<T> {
     ///
     /// The callback function receives the following arguments:
     ///
-    /// - The full virtual address range mapped by each visited page table descriptor, which may
-    ///   exceed the original range passed to `walk_range`, due to alignment to block boundaries.
+    /// - The range covered by the current step in the walk. This is always a subrange of `range`
+    ///   even when the descriptor covers a region that exceeds it.
     /// - The page table descriptor itself.
     /// - The level of a translation table the descriptor belongs to.
     ///


### PR DESCRIPTION
walk_range() does not widen the range argument to the callback function, so stop claiming this is the case in the doc comments