### PR TITLE
Add methods to get physical address of root table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### New features
+
+- Added `root_address`, `mark_active` and `mark_inactive` methods to `IdMap`, `LinearMap` and
+  `Mapping`. These may be used to activate and deactivate the page table manually rather than
+  calling `activate` and `deactivate`.
+
 ## 0.5.0
 
 ### Bug fixes

--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -276,9 +276,32 @@ impl IdMap {
     /// Returns the physical address of the root table.
     ///
     /// This may be used to activate the page table by setting the appropriate TTBRn_ELx if you wish
-    /// to do so yourself rather than by calling [`activate`](Self::activate).
+    /// to do so yourself rather than by calling [`activate`](Self::activate). Make sure to call
+    /// [`mark_active`](Self::mark_active) after doing so.
     pub fn root_address(&self) -> PhysicalAddress {
         self.mapping.root_address()
+    }
+
+    /// Marks the page table as active.
+    ///
+    /// This should be called if the page table is manually activated by calling
+    /// [`root_address`](Self::root_address) and setting some TTBR with it. This will cause
+    /// [`map_range`](Self::map_range) and [`modify_range`](Self::modify_range) to perform extra
+    /// checks to avoid violating break-before-make requirements.
+    ///
+    /// It is called automatically by [`activate`](Self::activate).
+    pub fn mark_active(&mut self, previous_ttbr: usize) {
+        self.mapping.mark_active(previous_ttbr);
+    }
+
+    /// Marks the page table as inactive.
+    ///
+    /// This may be called after manually disabling the use of the page table, such as by setting
+    /// the relevant TTBR to a different address.
+    ///
+    /// It is called automatically by [`deactivate`](Self::deactivate).
+    pub fn mark_inactive(&mut self) {
+        self.mapping.mark_inactive();
     }
 }
 

--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -272,6 +272,14 @@ impl IdMap {
     {
         self.mapping.walk_range(range, f)
     }
+
+    /// Returns the physical address of the root table.
+    ///
+    /// This may be used to activate the page table by setting the appropriate TTBRn_ELx if you wish
+    /// to do so yourself rather than by calling [`activate`](Self::activate).
+    pub fn root_address(&self) -> PhysicalAddress {
+        self.mapping.root_address()
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,7 @@
 //!
 //! Full support is provided for identity mapping ([`IdMap`](idmap::IdMap)) and linear mapping
 //! ([`LinearMap`](linearmap::LinearMap)). If you want to use a different mapping scheme, you must
-//! provide an implementation of the [`Translation`](paging::Translation) trait and then use
-//! [`Mapping`] directly.
+//! provide an implementation of the [`Translation`] trait and then use [`Mapping`] directly.
 //!
 //! # Example
 //!

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -284,6 +284,14 @@ impl LinearMap {
     {
         self.mapping.walk_range(range, f)
     }
+
+    /// Returns the physical address of the root table.
+    ///
+    /// This may be used to activate the page table by setting the appropriate TTBRn_ELx if you wish
+    /// to do so yourself rather than by calling [`activate`](Self::activate).
+    pub fn root_address(&self) -> PhysicalAddress {
+        self.mapping.root_address()
+    }
 }
 
 #[cfg(test)]

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -288,9 +288,32 @@ impl LinearMap {
     /// Returns the physical address of the root table.
     ///
     /// This may be used to activate the page table by setting the appropriate TTBRn_ELx if you wish
-    /// to do so yourself rather than by calling [`activate`](Self::activate).
+    /// to do so yourself rather than by calling [`activate`](Self::activate). Make sure to call
+    /// [`mark_active`](Self::mark_active) after doing so.
     pub fn root_address(&self) -> PhysicalAddress {
         self.mapping.root_address()
+    }
+
+    /// Marks the page table as active.
+    ///
+    /// This should be called if the page table is manually activated by calling
+    /// [`root_address`](Self::root_address) and setting some TTBR with it. This will cause
+    /// [`map_range`](Self::map_range) and [`modify_range`](Self::modify_range) to perform extra
+    /// checks to avoid violating break-before-make requirements.
+    ///
+    /// It is called automatically by [`activate`](Self::activate).
+    pub fn mark_active(&mut self, previous_ttbr: usize) {
+        self.mapping.mark_active(previous_ttbr);
+    }
+
+    /// Marks the page table as inactive.
+    ///
+    /// This may be called after manually disabling the use of the page table, such as by setting
+    /// the relevant TTBR to a different address.
+    ///
+    /// It is called automatically by [`deactivate`](Self::deactivate).
+    pub fn mark_inactive(&mut self) {
+        self.mapping.mark_inactive();
     }
 }
 


### PR DESCRIPTION
This is useful for applications which need to set TTBRn_ELx directly for some reason, such as those running in EL2 or EL3.