### PR TITLE
Add support for EL2 and EL3 page tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Added support for EL2 and EL3 page tables. This requires a new parameter to `IdMap::new`,
+  `LinearMap::new`, `Mapping::new` and `RootTable::new`.
+
 ### New features
 
 - Added `root_address`, `mark_active` and `mark_inactive` methods to `IdMap`, `LinearMap` and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "aarch64-paging"
 version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-description = "A library to manipulate AArch64 VMSA EL1 page tables."
+description = "A library to manipulate AArch64 VMSA page tables."
 authors = [
   "Ard Biesheuvel <ardb@google.com>",
   "Andrew Walbran <qwandor@google.com>",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![crates.io page](https://img.shields.io/crates/v/aarch64-paging.svg)](https://crates.io/crates/aarch64-paging)
 [![docs.rs page](https://docs.rs/aarch64-paging/badge.svg)](https://docs.rs/aarch64-paging)
 
-This crate provides a library to manipulate EL1 page tables conforming to the AArch64 Virtual Memory
+This crate provides a library to manipulate page tables conforming to the AArch64 Virtual Memory
 System Architecture.
 
 This is not an officially supported Google product.

--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -67,7 +67,7 @@ impl Translation for IdTranslation {
 /// const ROOT_LEVEL: usize = 1;
 ///
 /// // Create a new EL1 page table with identity mapping.
-/// let mut idmap = IdMap::new(ASID, ROOT_LEVEL, TranslationRegime::El1);
+/// let mut idmap = IdMap::new(ASID, ROOT_LEVEL, TranslationRegime::El1And0);
 /// // Map a 2 MiB region of memory as read-write.
 /// idmap.map_range(
 ///     &MemoryRegion::new(0x80200000, 0x80400000),
@@ -324,7 +324,7 @@ mod tests {
     #[test]
     fn map_valid() {
         // A single byte at the start of the address space.
-        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1And0);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -339,7 +339,7 @@ mod tests {
         );
 
         // Two pages at the start of the address space.
-        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1And0);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -354,7 +354,7 @@ mod tests {
         );
 
         // A single byte at the end of the address space.
-        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1And0);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -372,7 +372,7 @@ mod tests {
         );
 
         // Two pages, on the boundary between two subtables.
-        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1And0);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -387,7 +387,7 @@ mod tests {
         );
 
         // The entire valid address space.
-        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1And0);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -405,7 +405,7 @@ mod tests {
     #[test]
     fn map_break_before_make() {
         const BLOCK_SIZE: usize = PAGE_SIZE << BITS_PER_LEVEL;
-        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1And0);
         idmap
             .map_range_with_constraints(
                 &MemoryRegion::new(BLOCK_SIZE, 2 * BLOCK_SIZE),
@@ -428,7 +428,7 @@ mod tests {
             Ok(())
         );
 
-        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1And0);
         idmap
             .map_range(
                 &MemoryRegion::new(BLOCK_SIZE, 2 * BLOCK_SIZE),
@@ -559,7 +559,7 @@ mod tests {
 
     #[test]
     fn map_out_of_range() {
-        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1And0);
 
         // One byte, just past the edge of the valid range.
         assert_eq!(
@@ -588,7 +588,7 @@ mod tests {
     }
 
     fn make_map() -> IdMap {
-        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1And0);
         idmap
             .map_range(
                 &MemoryRegion::new(0, PAGE_SIZE * 2),
@@ -655,7 +655,7 @@ mod tests {
     #[test]
     fn breakup_invalid_block() {
         const BLOCK_RANGE: usize = 0x200000;
-        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1And0);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {

--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -8,8 +8,8 @@
 
 use crate::{
     paging::{
-        deallocate, Attributes, Constraints, Descriptor, ExceptionLevel, MemoryRegion, PageTable,
-        PhysicalAddress, Translation, VaRange, VirtualAddress,
+        deallocate, Attributes, Constraints, Descriptor, MemoryRegion, PageTable, PhysicalAddress,
+        Translation, TranslationRegime, VaRange, VirtualAddress,
     },
     MapError, Mapping,
 };
@@ -60,14 +60,14 @@ impl Translation for IdTranslation {
 /// ```no_run
 /// use aarch64_paging::{
 ///     idmap::IdMap,
-///     paging::{Attributes, ExceptionLevel, MemoryRegion},
+///     paging::{Attributes, MemoryRegion, TranslationRegime},
 /// };
 ///
 /// const ASID: usize = 1;
 /// const ROOT_LEVEL: usize = 1;
 ///
 /// // Create a new EL1 page table with identity mapping.
-/// let mut idmap = IdMap::new(ASID, ROOT_LEVEL, ExceptionLevel::El1);
+/// let mut idmap = IdMap::new(ASID, ROOT_LEVEL, TranslationRegime::El1);
 /// // Map a 2 MiB region of memory as read-write.
 /// idmap.map_range(
 ///     &MemoryRegion::new(0x80200000, 0x80400000),
@@ -104,13 +104,13 @@ pub struct IdMap {
 
 impl IdMap {
     /// Creates a new identity-mapping page table with the given ASID and root level.
-    pub fn new(asid: usize, rootlevel: usize, exception_level: ExceptionLevel) -> Self {
+    pub fn new(asid: usize, rootlevel: usize, translation_regime: TranslationRegime) -> Self {
         Self {
             mapping: Mapping::new(
                 IdTranslation,
                 asid,
                 rootlevel,
-                exception_level,
+                translation_regime,
                 VaRange::Lower,
             ),
         }
@@ -324,7 +324,7 @@ mod tests {
     #[test]
     fn map_valid() {
         // A single byte at the start of the address space.
-        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -339,7 +339,7 @@ mod tests {
         );
 
         // Two pages at the start of the address space.
-        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -354,7 +354,7 @@ mod tests {
         );
 
         // A single byte at the end of the address space.
-        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -372,7 +372,7 @@ mod tests {
         );
 
         // Two pages, on the boundary between two subtables.
-        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -387,7 +387,7 @@ mod tests {
         );
 
         // The entire valid address space.
-        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -405,7 +405,7 @@ mod tests {
     #[test]
     fn map_break_before_make() {
         const BLOCK_SIZE: usize = PAGE_SIZE << BITS_PER_LEVEL;
-        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
         idmap
             .map_range_with_constraints(
                 &MemoryRegion::new(BLOCK_SIZE, 2 * BLOCK_SIZE),
@@ -428,7 +428,7 @@ mod tests {
             Ok(())
         );
 
-        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
         idmap
             .map_range(
                 &MemoryRegion::new(BLOCK_SIZE, 2 * BLOCK_SIZE),
@@ -559,7 +559,7 @@ mod tests {
 
     #[test]
     fn map_out_of_range() {
-        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
 
         // One byte, just past the edge of the valid range.
         assert_eq!(
@@ -588,7 +588,7 @@ mod tests {
     }
 
     fn make_map() -> IdMap {
-        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
         idmap
             .map_range(
                 &MemoryRegion::new(0, PAGE_SIZE * 2),
@@ -655,7 +655,7 @@ mod tests {
     #[test]
     fn breakup_invalid_block() {
         const BLOCK_RANGE: usize = 0x200000;
-        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
+        let mut idmap = IdMap::new(1, 1, TranslationRegime::El1);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {

--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -8,8 +8,8 @@
 
 use crate::{
     paging::{
-        deallocate, Attributes, Constraints, Descriptor, MemoryRegion, PageTable, PhysicalAddress,
-        Translation, VaRange, VirtualAddress,
+        deallocate, Attributes, Constraints, Descriptor, ExceptionLevel, MemoryRegion, PageTable,
+        PhysicalAddress, Translation, VaRange, VirtualAddress,
     },
     MapError, Mapping,
 };
@@ -60,14 +60,14 @@ impl Translation for IdTranslation {
 /// ```no_run
 /// use aarch64_paging::{
 ///     idmap::IdMap,
-///     paging::{Attributes, MemoryRegion},
+///     paging::{Attributes, ExceptionLevel, MemoryRegion},
 /// };
 ///
 /// const ASID: usize = 1;
 /// const ROOT_LEVEL: usize = 1;
 ///
-/// // Create a new page table with identity mapping.
-/// let mut idmap = IdMap::new(ASID, ROOT_LEVEL);
+/// // Create a new EL1 page table with identity mapping.
+/// let mut idmap = IdMap::new(ASID, ROOT_LEVEL, ExceptionLevel::El1);
 /// // Map a 2 MiB region of memory as read-write.
 /// idmap.map_range(
 ///     &MemoryRegion::new(0x80200000, 0x80400000),
@@ -104,9 +104,15 @@ pub struct IdMap {
 
 impl IdMap {
     /// Creates a new identity-mapping page table with the given ASID and root level.
-    pub fn new(asid: usize, rootlevel: usize) -> Self {
+    pub fn new(asid: usize, rootlevel: usize, exception_level: ExceptionLevel) -> Self {
         Self {
-            mapping: Mapping::new(IdTranslation, asid, rootlevel, VaRange::Lower),
+            mapping: Mapping::new(
+                IdTranslation,
+                asid,
+                rootlevel,
+                exception_level,
+                VaRange::Lower,
+            ),
         }
     }
 
@@ -318,7 +324,7 @@ mod tests {
     #[test]
     fn map_valid() {
         // A single byte at the start of the address space.
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -333,7 +339,7 @@ mod tests {
         );
 
         // Two pages at the start of the address space.
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -348,7 +354,7 @@ mod tests {
         );
 
         // A single byte at the end of the address space.
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -366,7 +372,7 @@ mod tests {
         );
 
         // Two pages, on the boundary between two subtables.
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -381,7 +387,7 @@ mod tests {
         );
 
         // The entire valid address space.
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {
@@ -399,7 +405,7 @@ mod tests {
     #[test]
     fn map_break_before_make() {
         const BLOCK_SIZE: usize = PAGE_SIZE << BITS_PER_LEVEL;
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
         idmap
             .map_range_with_constraints(
                 &MemoryRegion::new(BLOCK_SIZE, 2 * BLOCK_SIZE),
@@ -422,7 +428,7 @@ mod tests {
             Ok(())
         );
 
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
         idmap
             .map_range(
                 &MemoryRegion::new(BLOCK_SIZE, 2 * BLOCK_SIZE),
@@ -553,7 +559,7 @@ mod tests {
 
     #[test]
     fn map_out_of_range() {
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
 
         // One byte, just past the edge of the valid range.
         assert_eq!(
@@ -582,7 +588,7 @@ mod tests {
     }
 
     fn make_map() -> IdMap {
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
         idmap
             .map_range(
                 &MemoryRegion::new(0, PAGE_SIZE * 2),
@@ -649,7 +655,7 @@ mod tests {
     #[test]
     fn breakup_invalid_block() {
         const BLOCK_RANGE: usize = 0x200000;
-        let mut idmap = IdMap::new(1, 1);
+        let mut idmap = IdMap::new(1, 1, ExceptionLevel::El1);
         // SAFETY: This doesn't actually activate the page table in tests, it just treats it as
         // active for the sake of BBM rules.
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 //!
 //! Currently it only supports:
 //!   - stage 1 page tables
-//!   - EL1
 //!   - 4 KiB pages
 //!
 //! Full support is provided for identity mapping ([`IdMap`](idmap::IdMap)) and linear mapping
@@ -19,14 +18,14 @@
 //! # #[cfg(feature = "alloc")] {
 //! use aarch64_paging::{
 //!     idmap::IdMap,
-//!     paging::{Attributes, MemoryRegion},
+//!     paging::{Attributes, ExceptionLevel, MemoryRegion},
 //! };
 //!
 //! const ASID: usize = 1;
 //! const ROOT_LEVEL: usize = 1;
 //!
-//! // Create a new page table with identity mapping.
-//! let mut idmap = IdMap::new(ASID, ROOT_LEVEL);
+//! // Create a new EL1 page table with identity mapping.
+//! let mut idmap = IdMap::new(ASID, ROOT_LEVEL, ExceptionLevel::El1);
 //! // Map a 2 MiB region of memory as read-write.
 //! idmap.map_range(
 //!     &MemoryRegion::new(0x80200000, 0x80400000),
@@ -56,8 +55,8 @@ extern crate alloc;
 use core::arch::asm;
 use core::fmt::{self, Display, Formatter};
 use paging::{
-    Attributes, Constraints, Descriptor, MemoryRegion, PhysicalAddress, RootTable, Translation,
-    VaRange, VirtualAddress,
+    Attributes, Constraints, Descriptor, ExceptionLevel, MemoryRegion, PhysicalAddress, RootTable,
+    Translation, VaRange, VirtualAddress,
 };
 
 /// An error attempting to map some range in the page table.
@@ -119,9 +118,15 @@ pub struct Mapping<T: Translation + Clone> {
 
 impl<T: Translation + Clone> Mapping<T> {
     /// Creates a new page table with the given ASID, root level and translation mapping.
-    pub fn new(translation: T, asid: usize, rootlevel: usize, va_range: VaRange) -> Self {
+    pub fn new(
+        translation: T,
+        asid: usize,
+        rootlevel: usize,
+        exception_level: ExceptionLevel,
+        va_range: VaRange,
+    ) -> Self {
         Self {
-            root: RootTable::new(translation, rootlevel, va_range),
+            root: RootTable::new(translation, rootlevel, exception_level, va_range),
             asid,
             previous_ttbr: None,
         }
@@ -132,13 +137,13 @@ impl<T: Translation + Clone> Mapping<T> {
         self.previous_ttbr.is_some()
     }
 
-    /// Activates the page table by setting `TTBRn_EL1` to point to it, and saves the previous value
-    /// of `TTBRn_EL1` so that it may later be restored by [`deactivate`](Self::deactivate).
+    /// Activates the page table by setting `TTBRn_ELx` to point to it, and saves the previous value
+    /// of `TTBRn_ELx` so that it may later be restored by [`deactivate`](Self::deactivate).
     ///
-    /// Panics if a previous value of `TTBRn_EL1` is already saved and not yet used by a call to
+    /// Panics if a previous value of `TTBRn_ELx` is already saved and not yet used by a call to
     /// `deactivate`.
     ///
-    /// In test builds or builds that do not target aarch64, the `TTBRn_EL1` access is omitted.
+    /// In test builds or builds that do not target aarch64, the `TTBRn_ELx` access is omitted.
     ///
     /// # Safety
     ///
@@ -154,11 +159,11 @@ impl<T: Translation + Clone> Mapping<T> {
 
         #[cfg(all(not(test), target_arch = "aarch64"))]
         // SAFETY: Safe because we trust that self.root_address() returns a valid physical address
-        // of a page table, and the `Drop` implementation will reset `TTBRn_EL1` before it becomes
+        // of a page table, and the `Drop` implementation will reset `TTBRn_ELx` before it becomes
         // invalid.
         unsafe {
-            match self.root.va_range() {
-                VaRange::Lower => asm!(
+            match (self.root.exception_level(), self.root.va_range()) {
+                (ExceptionLevel::El1, VaRange::Lower) => asm!(
                     "mrs   {previous_ttbr}, ttbr0_el1",
                     "msr   ttbr0_el1, {ttbrval}",
                     "isb",
@@ -166,7 +171,7 @@ impl<T: Translation + Clone> Mapping<T> {
                     previous_ttbr = out(reg) previous_ttbr,
                     options(preserves_flags),
                 ),
-                VaRange::Upper => asm!(
+                (ExceptionLevel::El1, VaRange::Upper) => asm!(
                     "mrs   {previous_ttbr}, ttbr1_el1",
                     "msr   ttbr1_el1, {ttbrval}",
                     "isb",
@@ -174,19 +179,38 @@ impl<T: Translation + Clone> Mapping<T> {
                     previous_ttbr = out(reg) previous_ttbr,
                     options(preserves_flags),
                 ),
+                (ExceptionLevel::El2, VaRange::Lower) => asm!(
+                    "mrs   {previous_ttbr}, ttbr0_el2",
+                    "msr   ttbr0_el2, {ttbrval}",
+                    "isb",
+                    ttbrval = in(reg) self.root_address().0 | (self.asid << 48),
+                    previous_ttbr = out(reg) previous_ttbr,
+                    options(preserves_flags),
+                ),
+                (ExceptionLevel::El3, VaRange::Lower) => asm!(
+                    "mrs   {previous_ttbr}, ttbr0_el3",
+                    "msr   ttbr0_el3, {ttbrval}",
+                    "isb",
+                    ttbrval = in(reg) self.root_address().0 | (self.asid << 48),
+                    previous_ttbr = out(reg) previous_ttbr,
+                    options(preserves_flags),
+                ),
+                _ => {
+                    panic!("Invalid combination of exception level and VA range.");
+                }
             }
         }
         self.mark_active(previous_ttbr);
     }
 
-    /// Deactivates the page table, by setting `TTBRn_EL1` back to the value it had before
+    /// Deactivates the page table, by setting `TTBRn_ELx` back to the value it had before
     /// [`activate`](Self::activate) was called, and invalidating the TLB for this page table's
     /// configured ASID.
     ///
-    /// Panics if there is no saved `TTBRn_EL1` value because `activate` has not previously been
+    /// Panics if there is no saved `TTBRn_ELx` value because `activate` has not previously been
     /// called.
     ///
-    /// In test builds or builds that do not target aarch64, the `TTBRn_EL1` access is omitted.
+    /// In test builds or builds that do not target aarch64, the `TTBRn_ELx` access is omitted.
     ///
     /// # Safety
     ///
@@ -196,11 +220,11 @@ impl<T: Translation + Clone> Mapping<T> {
         assert!(self.active());
 
         #[cfg(all(not(test), target_arch = "aarch64"))]
-        // SAFETY: Safe because this just restores the previously saved value of `TTBRn_EL1`, which
+        // SAFETY: Safe because this just restores the previously saved value of `TTBRn_ELx`, which
         // must have been valid.
         unsafe {
-            match self.root.va_range() {
-                VaRange::Lower => asm!(
+            match (self.root.exception_level(), self.root.va_range()) {
+                (ExceptionLevel::El1, VaRange::Lower) => asm!(
                     "msr   ttbr0_el1, {ttbrval}",
                     "isb",
                     "tlbi  aside1, {asid}",
@@ -210,7 +234,7 @@ impl<T: Translation + Clone> Mapping<T> {
                     ttbrval = in(reg) self.previous_ttbr.unwrap(),
                     options(preserves_flags),
                 ),
-                VaRange::Upper => asm!(
+                (ExceptionLevel::El1, VaRange::Upper) => asm!(
                     "msr   ttbr1_el1, {ttbrval}",
                     "isb",
                     "tlbi  aside1, {asid}",
@@ -220,6 +244,29 @@ impl<T: Translation + Clone> Mapping<T> {
                     ttbrval = in(reg) self.previous_ttbr.unwrap(),
                     options(preserves_flags),
                 ),
+                (ExceptionLevel::El2, VaRange::Lower) => asm!(
+                    "msr   ttbr0_el2, {ttbrval}",
+                    "isb",
+                    "tlbi  aside1, {asid}",
+                    "dsb   nsh",
+                    "isb",
+                    asid = in(reg) self.asid << 48,
+                    ttbrval = in(reg) self.previous_ttbr.unwrap(),
+                    options(preserves_flags),
+                ),
+                (ExceptionLevel::El3, VaRange::Lower) => asm!(
+                    "msr   ttbr0_el3, {ttbrval}",
+                    "isb",
+                    "tlbi  aside1, {asid}",
+                    "dsb   nsh",
+                    "isb",
+                    asid = in(reg) self.asid << 48,
+                    ttbrval = in(reg) self.previous_ttbr.unwrap(),
+                    options(preserves_flags),
+                ),
+                _ => {
+                    panic!("Invalid combination of exception level and VA range.");
+                }
             }
         }
         self.mark_inactive();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! const ROOT_LEVEL: usize = 1;
 //!
 //! // Create a new EL1 page table with identity mapping.
-//! let mut idmap = IdMap::new(ASID, ROOT_LEVEL, TranslationRegime::El1);
+//! let mut idmap = IdMap::new(ASID, ROOT_LEVEL, TranslationRegime::El1And0);
 //! // Map a 2 MiB region of memory as read-write.
 //! idmap.map_range(
 //!     &MemoryRegion::new(0x80200000, 0x80400000),
@@ -166,7 +166,7 @@ impl<T: Translation + Clone> Mapping<T> {
         // invalid.
         unsafe {
             match (self.root.translation_regime(), self.root.va_range()) {
-                (TranslationRegime::El1, VaRange::Lower) => asm!(
+                (TranslationRegime::El1And0, VaRange::Lower) => asm!(
                     "mrs   {previous_ttbr}, ttbr0_el1",
                     "msr   ttbr0_el1, {ttbrval}",
                     "isb",
@@ -174,7 +174,7 @@ impl<T: Translation + Clone> Mapping<T> {
                     previous_ttbr = out(reg) previous_ttbr,
                     options(preserves_flags),
                 ),
-                (TranslationRegime::El1, VaRange::Upper) => asm!(
+                (TranslationRegime::El1And0, VaRange::Upper) => asm!(
                     "mrs   {previous_ttbr}, ttbr1_el1",
                     "msr   ttbr1_el1, {ttbrval}",
                     "isb",
@@ -227,7 +227,7 @@ impl<T: Translation + Clone> Mapping<T> {
         // must have been valid.
         unsafe {
             match (self.root.translation_regime(), self.root.va_range()) {
-                (TranslationRegime::El1, VaRange::Lower) => asm!(
+                (TranslationRegime::El1And0, VaRange::Lower) => asm!(
                     "msr   ttbr0_el1, {ttbrval}",
                     "isb",
                     "tlbi  aside1, {asid}",
@@ -237,7 +237,7 @@ impl<T: Translation + Clone> Mapping<T> {
                     ttbrval = in(reg) self.previous_ttbr.unwrap(),
                     options(preserves_flags),
                 ),
-                (TranslationRegime::El1, VaRange::Upper) => asm!(
+                (TranslationRegime::El1And0, VaRange::Upper) => asm!(
                     "msr   ttbr1_el1, {ttbrval}",
                     "isb",
                     "tlbi  aside1, {asid}",

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -8,8 +8,8 @@
 
 use crate::{
     paging::{
-        deallocate, is_aligned, Attributes, Constraints, Descriptor, ExceptionLevel, MemoryRegion,
-        PageTable, PhysicalAddress, Translation, VaRange, VirtualAddress, PAGE_SIZE,
+        deallocate, is_aligned, Attributes, Constraints, Descriptor, MemoryRegion, PageTable,
+        PhysicalAddress, Translation, TranslationRegime, VaRange, VirtualAddress, PAGE_SIZE,
     },
     MapError, Mapping,
 };
@@ -110,7 +110,7 @@ impl LinearMap {
         asid: usize,
         rootlevel: usize,
         offset: isize,
-        exception_level: ExceptionLevel,
+        translation_regime: TranslationRegime,
         va_range: VaRange,
     ) -> Self {
         Self {
@@ -118,7 +118,7 @@ impl LinearMap {
                 LinearTranslation::new(offset),
                 asid,
                 rootlevel,
-                exception_level,
+                translation_regime,
                 va_range,
             ),
         }
@@ -344,7 +344,7 @@ mod tests {
     #[test]
     fn map_valid() {
         // A single byte at the start of the address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096, ExceptionLevel::El1, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 4096, TranslationRegime::El1, VaRange::Lower);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, 1),
@@ -354,7 +354,7 @@ mod tests {
         );
 
         // Two pages at the start of the address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096, ExceptionLevel::El1, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 4096, TranslationRegime::El1, VaRange::Lower);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, PAGE_SIZE * 2),
@@ -364,7 +364,7 @@ mod tests {
         );
 
         // A single byte at the end of the address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096, ExceptionLevel::El1, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 4096, TranslationRegime::El1, VaRange::Lower);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(
@@ -383,7 +383,7 @@ mod tests {
             1,
             1,
             LEVEL_2_BLOCK_SIZE as isize,
-            ExceptionLevel::El1,
+            TranslationRegime::El1,
             VaRange::Lower,
         );
         assert_eq!(
@@ -402,7 +402,7 @@ mod tests {
             1,
             1,
             -(PAGE_SIZE as isize),
-            ExceptionLevel::El1,
+            TranslationRegime::El1,
             VaRange::Lower,
         );
         assert_eq!(
@@ -418,7 +418,7 @@ mod tests {
             1,
             1,
             -(PAGE_SIZE as isize),
-            ExceptionLevel::El1,
+            TranslationRegime::El1,
             VaRange::Lower,
         );
         assert_eq!(
@@ -434,7 +434,7 @@ mod tests {
             1,
             1,
             -(PAGE_SIZE as isize),
-            ExceptionLevel::El1,
+            TranslationRegime::El1,
             VaRange::Lower,
         );
         assert_eq!(
@@ -455,7 +455,7 @@ mod tests {
             1,
             1,
             -(LEVEL_2_BLOCK_SIZE as isize),
-            ExceptionLevel::El1,
+            TranslationRegime::El1,
             VaRange::Lower,
         );
         assert_eq!(
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn map_out_of_range() {
-        let mut pagetable = LinearMap::new(1, 1, 4096, ExceptionLevel::El1, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 4096, TranslationRegime::El1, VaRange::Lower);
 
         // One byte, just past the edge of the valid range.
         assert_eq!(
@@ -499,7 +499,7 @@ mod tests {
 
     #[test]
     fn map_invalid_offset() {
-        let mut pagetable = LinearMap::new(1, 1, -4096, ExceptionLevel::El1, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, -4096, TranslationRegime::El1, VaRange::Lower);
 
         // One byte, with an offset which would map it to a negative IPA.
         assert_eq!(
@@ -599,7 +599,7 @@ mod tests {
     #[test]
     fn block_mapping() {
         // Test that block mapping is used when the PA is appropriately aligned...
-        let mut pagetable = LinearMap::new(1, 1, 1 << 30, ExceptionLevel::El1, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 1 << 30, TranslationRegime::El1, VaRange::Lower);
         pagetable
             .map_range(
                 &MemoryRegion::new(0, 1 << 30),
@@ -612,7 +612,7 @@ mod tests {
         );
 
         // ...but not when it is not.
-        let mut pagetable = LinearMap::new(1, 1, 1 << 29, ExceptionLevel::El1, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 1 << 29, TranslationRegime::El1, VaRange::Lower);
         pagetable
             .map_range(
                 &MemoryRegion::new(0, 1 << 30),
@@ -626,7 +626,7 @@ mod tests {
     }
 
     fn make_map() -> LinearMap {
-        let mut lmap = LinearMap::new(1, 1, 4096, ExceptionLevel::El1, VaRange::Lower);
+        let mut lmap = LinearMap::new(1, 1, 4096, TranslationRegime::El1, VaRange::Lower);
         // Mapping VA range 0x0 - 0x2000 to PA range 0x1000 - 0x3000
         lmap.map_range(&MemoryRegion::new(0, PAGE_SIZE * 2), Attributes::NORMAL)
             .unwrap();
@@ -672,7 +672,7 @@ mod tests {
     fn breakup_invalid_block() {
         const BLOCK_RANGE: usize = 0x200000;
 
-        let mut lmap = LinearMap::new(1, 1, 0x1000, ExceptionLevel::El1, VaRange::Lower);
+        let mut lmap = LinearMap::new(1, 1, 0x1000, TranslationRegime::El1, VaRange::Lower);
         lmap.map_range(
             &MemoryRegion::new(0, BLOCK_RANGE),
             Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::SWFLAG_0,

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -344,7 +344,7 @@ mod tests {
     #[test]
     fn map_valid() {
         // A single byte at the start of the address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096, TranslationRegime::El1, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 4096, TranslationRegime::El1And0, VaRange::Lower);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, 1),
@@ -354,7 +354,7 @@ mod tests {
         );
 
         // Two pages at the start of the address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096, TranslationRegime::El1, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 4096, TranslationRegime::El1And0, VaRange::Lower);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, PAGE_SIZE * 2),
@@ -364,7 +364,7 @@ mod tests {
         );
 
         // A single byte at the end of the address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096, TranslationRegime::El1, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 4096, TranslationRegime::El1And0, VaRange::Lower);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(
@@ -383,7 +383,7 @@ mod tests {
             1,
             1,
             LEVEL_2_BLOCK_SIZE as isize,
-            TranslationRegime::El1,
+            TranslationRegime::El1And0,
             VaRange::Lower,
         );
         assert_eq!(
@@ -402,7 +402,7 @@ mod tests {
             1,
             1,
             -(PAGE_SIZE as isize),
-            TranslationRegime::El1,
+            TranslationRegime::El1And0,
             VaRange::Lower,
         );
         assert_eq!(
@@ -418,7 +418,7 @@ mod tests {
             1,
             1,
             -(PAGE_SIZE as isize),
-            TranslationRegime::El1,
+            TranslationRegime::El1And0,
             VaRange::Lower,
         );
         assert_eq!(
@@ -434,7 +434,7 @@ mod tests {
             1,
             1,
             -(PAGE_SIZE as isize),
-            TranslationRegime::El1,
+            TranslationRegime::El1And0,
             VaRange::Lower,
         );
         assert_eq!(
@@ -455,7 +455,7 @@ mod tests {
             1,
             1,
             -(LEVEL_2_BLOCK_SIZE as isize),
-            TranslationRegime::El1,
+            TranslationRegime::El1And0,
             VaRange::Lower,
         );
         assert_eq!(
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn map_out_of_range() {
-        let mut pagetable = LinearMap::new(1, 1, 4096, TranslationRegime::El1, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 4096, TranslationRegime::El1And0, VaRange::Lower);
 
         // One byte, just past the edge of the valid range.
         assert_eq!(
@@ -499,7 +499,7 @@ mod tests {
 
     #[test]
     fn map_invalid_offset() {
-        let mut pagetable = LinearMap::new(1, 1, -4096, TranslationRegime::El1, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, -4096, TranslationRegime::El1And0, VaRange::Lower);
 
         // One byte, with an offset which would map it to a negative IPA.
         assert_eq!(
@@ -599,7 +599,8 @@ mod tests {
     #[test]
     fn block_mapping() {
         // Test that block mapping is used when the PA is appropriately aligned...
-        let mut pagetable = LinearMap::new(1, 1, 1 << 30, TranslationRegime::El1, VaRange::Lower);
+        let mut pagetable =
+            LinearMap::new(1, 1, 1 << 30, TranslationRegime::El1And0, VaRange::Lower);
         pagetable
             .map_range(
                 &MemoryRegion::new(0, 1 << 30),
@@ -612,7 +613,8 @@ mod tests {
         );
 
         // ...but not when it is not.
-        let mut pagetable = LinearMap::new(1, 1, 1 << 29, TranslationRegime::El1, VaRange::Lower);
+        let mut pagetable =
+            LinearMap::new(1, 1, 1 << 29, TranslationRegime::El1And0, VaRange::Lower);
         pagetable
             .map_range(
                 &MemoryRegion::new(0, 1 << 30),
@@ -626,7 +628,7 @@ mod tests {
     }
 
     fn make_map() -> LinearMap {
-        let mut lmap = LinearMap::new(1, 1, 4096, TranslationRegime::El1, VaRange::Lower);
+        let mut lmap = LinearMap::new(1, 1, 4096, TranslationRegime::El1And0, VaRange::Lower);
         // Mapping VA range 0x0 - 0x2000 to PA range 0x1000 - 0x3000
         lmap.map_range(&MemoryRegion::new(0, PAGE_SIZE * 2), Attributes::NORMAL)
             .unwrap();
@@ -672,7 +674,7 @@ mod tests {
     fn breakup_invalid_block() {
         const BLOCK_RANGE: usize = 0x200000;
 
-        let mut lmap = LinearMap::new(1, 1, 0x1000, TranslationRegime::El1, VaRange::Lower);
+        let mut lmap = LinearMap::new(1, 1, 0x1000, TranslationRegime::El1And0, VaRange::Lower);
         lmap.map_range(
             &MemoryRegion::new(0, BLOCK_RANGE),
             Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::SWFLAG_0,

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -8,8 +8,8 @@
 
 use crate::{
     paging::{
-        deallocate, is_aligned, Attributes, Constraints, Descriptor, MemoryRegion, PageTable,
-        PhysicalAddress, Translation, VaRange, VirtualAddress, PAGE_SIZE,
+        deallocate, is_aligned, Attributes, Constraints, Descriptor, ExceptionLevel, MemoryRegion,
+        PageTable, PhysicalAddress, Translation, VaRange, VirtualAddress, PAGE_SIZE,
     },
     MapError, Mapping,
 };
@@ -106,9 +106,21 @@ impl LinearMap {
     /// `va + offset`.
     ///
     /// The `offset` must be a multiple of [`PAGE_SIZE`]; if not this will panic.
-    pub fn new(asid: usize, rootlevel: usize, offset: isize, va_range: VaRange) -> Self {
+    pub fn new(
+        asid: usize,
+        rootlevel: usize,
+        offset: isize,
+        exception_level: ExceptionLevel,
+        va_range: VaRange,
+    ) -> Self {
         Self {
-            mapping: Mapping::new(LinearTranslation::new(offset), asid, rootlevel, va_range),
+            mapping: Mapping::new(
+                LinearTranslation::new(offset),
+                asid,
+                rootlevel,
+                exception_level,
+                va_range,
+            ),
         }
     }
 
@@ -332,7 +344,7 @@ mod tests {
     #[test]
     fn map_valid() {
         // A single byte at the start of the address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 4096, ExceptionLevel::El1, VaRange::Lower);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, 1),
@@ -342,7 +354,7 @@ mod tests {
         );
 
         // Two pages at the start of the address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 4096, ExceptionLevel::El1, VaRange::Lower);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, PAGE_SIZE * 2),
@@ -352,7 +364,7 @@ mod tests {
         );
 
         // A single byte at the end of the address space.
-        let mut pagetable = LinearMap::new(1, 1, 4096, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 4096, ExceptionLevel::El1, VaRange::Lower);
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(
@@ -367,7 +379,13 @@ mod tests {
         // The entire valid address space. Use an offset that is a multiple of the level 2 block
         // size to avoid mapping everything as pages as that is really slow.
         const LEVEL_2_BLOCK_SIZE: usize = PAGE_SIZE << BITS_PER_LEVEL;
-        let mut pagetable = LinearMap::new(1, 1, LEVEL_2_BLOCK_SIZE as isize, VaRange::Lower);
+        let mut pagetable = LinearMap::new(
+            1,
+            1,
+            LEVEL_2_BLOCK_SIZE as isize,
+            ExceptionLevel::El1,
+            VaRange::Lower,
+        );
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
@@ -380,7 +398,13 @@ mod tests {
     #[test]
     fn map_valid_negative_offset() {
         // A single byte which maps to IPA 0.
-        let mut pagetable = LinearMap::new(1, 1, -(PAGE_SIZE as isize), VaRange::Lower);
+        let mut pagetable = LinearMap::new(
+            1,
+            1,
+            -(PAGE_SIZE as isize),
+            ExceptionLevel::El1,
+            VaRange::Lower,
+        );
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(PAGE_SIZE, PAGE_SIZE + 1),
@@ -390,7 +414,13 @@ mod tests {
         );
 
         // Two pages at the start of the address space.
-        let mut pagetable = LinearMap::new(1, 1, -(PAGE_SIZE as isize), VaRange::Lower);
+        let mut pagetable = LinearMap::new(
+            1,
+            1,
+            -(PAGE_SIZE as isize),
+            ExceptionLevel::El1,
+            VaRange::Lower,
+        );
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(PAGE_SIZE, PAGE_SIZE * 3),
@@ -400,7 +430,13 @@ mod tests {
         );
 
         // A single byte at the end of the address space.
-        let mut pagetable = LinearMap::new(1, 1, -(PAGE_SIZE as isize), VaRange::Lower);
+        let mut pagetable = LinearMap::new(
+            1,
+            1,
+            -(PAGE_SIZE as isize),
+            ExceptionLevel::El1,
+            VaRange::Lower,
+        );
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(
@@ -415,7 +451,13 @@ mod tests {
         // The entire valid address space. Use an offset that is a multiple of the level 2 block
         // size to avoid mapping everything as pages as that is really slow.
         const LEVEL_2_BLOCK_SIZE: usize = PAGE_SIZE << BITS_PER_LEVEL;
-        let mut pagetable = LinearMap::new(1, 1, -(LEVEL_2_BLOCK_SIZE as isize), VaRange::Lower);
+        let mut pagetable = LinearMap::new(
+            1,
+            1,
+            -(LEVEL_2_BLOCK_SIZE as isize),
+            ExceptionLevel::El1,
+            VaRange::Lower,
+        );
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(LEVEL_2_BLOCK_SIZE, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
@@ -427,7 +469,7 @@ mod tests {
 
     #[test]
     fn map_out_of_range() {
-        let mut pagetable = LinearMap::new(1, 1, 4096, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 4096, ExceptionLevel::El1, VaRange::Lower);
 
         // One byte, just past the edge of the valid range.
         assert_eq!(
@@ -457,7 +499,7 @@ mod tests {
 
     #[test]
     fn map_invalid_offset() {
-        let mut pagetable = LinearMap::new(1, 1, -4096, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, -4096, ExceptionLevel::El1, VaRange::Lower);
 
         // One byte, with an offset which would map it to a negative IPA.
         assert_eq!(
@@ -557,7 +599,7 @@ mod tests {
     #[test]
     fn block_mapping() {
         // Test that block mapping is used when the PA is appropriately aligned...
-        let mut pagetable = LinearMap::new(1, 1, 1 << 30, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 1 << 30, ExceptionLevel::El1, VaRange::Lower);
         pagetable
             .map_range(
                 &MemoryRegion::new(0, 1 << 30),
@@ -570,7 +612,7 @@ mod tests {
         );
 
         // ...but not when it is not.
-        let mut pagetable = LinearMap::new(1, 1, 1 << 29, VaRange::Lower);
+        let mut pagetable = LinearMap::new(1, 1, 1 << 29, ExceptionLevel::El1, VaRange::Lower);
         pagetable
             .map_range(
                 &MemoryRegion::new(0, 1 << 30),
@@ -584,7 +626,7 @@ mod tests {
     }
 
     fn make_map() -> LinearMap {
-        let mut lmap = LinearMap::new(1, 1, 4096, VaRange::Lower);
+        let mut lmap = LinearMap::new(1, 1, 4096, ExceptionLevel::El1, VaRange::Lower);
         // Mapping VA range 0x0 - 0x2000 to PA range 0x1000 - 0x3000
         lmap.map_range(&MemoryRegion::new(0, PAGE_SIZE * 2), Attributes::NORMAL)
             .unwrap();
@@ -630,7 +672,7 @@ mod tests {
     fn breakup_invalid_block() {
         const BLOCK_RANGE: usize = 0x200000;
 
-        let mut lmap = LinearMap::new(1, 1, 0x1000, VaRange::Lower);
+        let mut lmap = LinearMap::new(1, 1, 0x1000, ExceptionLevel::El1, VaRange::Lower);
         lmap.map_range(
             &MemoryRegion::new(0, BLOCK_RANGE),
             Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::SWFLAG_0,

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -42,12 +42,12 @@ pub enum VaRange {
 /// This depends on the exception level, among other things.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum TranslationRegime {
-    /// EL1
-    El1,
-    /// EL2
-    El2,
-    /// EL3
+    /// Secure EL3.
     El3,
+    /// Non-secure EL2.
+    El2,
+    /// Non-secure EL1&0, stage 1.
+    El1And0,
 }
 
 /// An aarch64 virtual address, the input type of a stage 1 page table.


### PR DESCRIPTION
This adds a parameter to the constructors to specify which exception level the page table is intended for, and then uses it in `activate` and `deactivate` to choose the appropriate TTBR.