### PR TITLE
Add more attribute bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 
 - Added support for EL2 and EL3 page tables. This requires a new parameter to `IdMap::new`,
   `LinearMap::new`, `Mapping::new` and `RootTable::new`.
+- `Attributes::EXECUTE_NEVER` renamed to `Attributes::UXN`.
 
 ### New features
 
 - Added `root_address`, `mark_active` and `mark_inactive` methods to `IdMap`, `LinearMap` and
   `Mapping`. These may be used to activate and deactivate the page table manually rather than
   calling `activate` and `deactivate`.
+- Added `NS` and `PXN` bits to `Attributes`.
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Added support for EL2 and EL3 page tables. This requires a new parameter to `IdMap::new`,
   `LinearMap::new`, `Mapping::new` and `RootTable::new`.
 - `Attributes::EXECUTE_NEVER` renamed to `Attributes::UXN`.
+- `Attributes::DEVICE_NGNRE` and `NORMAL` have been removed in favour of `ATTRIBUTE_INDEX_*`,
+  `OUTER_SHAREABLE` and `INNER_SHAREABLE`, to avoid making assumptions about how the MAIR registers
+  are programmed.
 
 ### New features
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,14 @@
 //!
 //! const ASID: usize = 1;
 //! const ROOT_LEVEL: usize = 1;
+//! const NORMAL_CACHEABLE: Attributes = Attributes::ATTRIBUTE_INDEX_1.union(Attributes::INNER_SHAREABLE);
 //!
 //! // Create a new EL1 page table with identity mapping.
 //! let mut idmap = IdMap::new(ASID, ROOT_LEVEL, TranslationRegime::El1And0);
 //! // Map a 2 MiB region of memory as read-write.
 //! idmap.map_range(
 //!     &MemoryRegion::new(0x80200000, 0x80400000),
-//!     Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::VALID,
+//!     NORMAL_CACHEABLE | Attributes::NON_GLOBAL | Attributes::VALID,
 //! ).unwrap();
 //! // SAFETY: Everything the program uses is within the 2 MiB region mapped above.
 //! unsafe {
@@ -334,7 +335,9 @@ impl<T: Translation + Clone> Mapping<T> {
 
                     let desc_flags = d.flags().unwrap();
 
-                    if (desc_flags ^ flags).intersects(Attributes::NORMAL) {
+                    if (desc_flags ^ flags).intersects(
+                        Attributes::ATTRIBUTE_INDEX_MASK | Attributes::SHAREABILITY_MASK,
+                    ) {
                         // Cannot change memory type
                         return Err(err);
                     }

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -340,6 +340,8 @@ mod tests {
     const MAX_ADDRESS_FOR_ROOT_LEVEL_1: usize = 1 << 39;
     const GIB_512_S: isize = 512 * 1024 * 1024 * 1024;
     const GIB_512: usize = 512 * 1024 * 1024 * 1024;
+    const NORMAL_CACHEABLE: Attributes =
+        Attributes::ATTRIBUTE_INDEX_1.union(Attributes::INNER_SHAREABLE);
 
     #[test]
     fn map_valid() {
@@ -348,7 +350,7 @@ mod tests {
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, 1),
-                Attributes::NORMAL | Attributes::VALID
+                NORMAL_CACHEABLE | Attributes::VALID
             ),
             Ok(())
         );
@@ -358,7 +360,7 @@ mod tests {
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, PAGE_SIZE * 2),
-                Attributes::NORMAL | Attributes::VALID
+                NORMAL_CACHEABLE | Attributes::VALID
             ),
             Ok(())
         );
@@ -371,7 +373,7 @@ mod tests {
                     MAX_ADDRESS_FOR_ROOT_LEVEL_1 - 1,
                     MAX_ADDRESS_FOR_ROOT_LEVEL_1
                 ),
-                Attributes::NORMAL | Attributes::VALID
+                NORMAL_CACHEABLE | Attributes::VALID
             ),
             Ok(())
         );
@@ -389,7 +391,7 @@ mod tests {
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
-                Attributes::NORMAL | Attributes::VALID
+                NORMAL_CACHEABLE | Attributes::VALID
             ),
             Ok(())
         );
@@ -408,7 +410,7 @@ mod tests {
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(PAGE_SIZE, PAGE_SIZE + 1),
-                Attributes::NORMAL | Attributes::VALID
+                NORMAL_CACHEABLE | Attributes::VALID
             ),
             Ok(())
         );
@@ -424,7 +426,7 @@ mod tests {
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(PAGE_SIZE, PAGE_SIZE * 3),
-                Attributes::NORMAL | Attributes::VALID
+                NORMAL_CACHEABLE | Attributes::VALID
             ),
             Ok(())
         );
@@ -443,7 +445,7 @@ mod tests {
                     MAX_ADDRESS_FOR_ROOT_LEVEL_1 - 1,
                     MAX_ADDRESS_FOR_ROOT_LEVEL_1
                 ),
-                Attributes::NORMAL | Attributes::VALID
+                NORMAL_CACHEABLE | Attributes::VALID
             ),
             Ok(())
         );
@@ -461,7 +463,7 @@ mod tests {
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(LEVEL_2_BLOCK_SIZE, MAX_ADDRESS_FOR_ROOT_LEVEL_1),
-                Attributes::NORMAL | Attributes::VALID
+                NORMAL_CACHEABLE | Attributes::VALID
             ),
             Ok(())
         );
@@ -478,7 +480,7 @@ mod tests {
                     MAX_ADDRESS_FOR_ROOT_LEVEL_1,
                     MAX_ADDRESS_FOR_ROOT_LEVEL_1 + 1,
                 ),
-                Attributes::NORMAL | Attributes::VALID
+                NORMAL_CACHEABLE | Attributes::VALID
             ),
             Err(MapError::AddressRange(VirtualAddress(
                 MAX_ADDRESS_FOR_ROOT_LEVEL_1 + PAGE_SIZE
@@ -489,7 +491,7 @@ mod tests {
         assert_eq!(
             pagetable.map_range(
                 &MemoryRegion::new(0, MAX_ADDRESS_FOR_ROOT_LEVEL_1 + 1),
-                Attributes::NORMAL | Attributes::VALID
+                NORMAL_CACHEABLE | Attributes::VALID
             ),
             Err(MapError::AddressRange(VirtualAddress(
                 MAX_ADDRESS_FOR_ROOT_LEVEL_1 + PAGE_SIZE
@@ -503,7 +505,7 @@ mod tests {
 
         // One byte, with an offset which would map it to a negative IPA.
         assert_eq!(
-            pagetable.map_range(&MemoryRegion::new(0, 1), Attributes::NORMAL,),
+            pagetable.map_range(&MemoryRegion::new(0, 1), NORMAL_CACHEABLE),
             Err(MapError::InvalidVirtualAddress(VirtualAddress(0)))
         );
     }
@@ -604,7 +606,7 @@ mod tests {
         pagetable
             .map_range(
                 &MemoryRegion::new(0, 1 << 30),
-                Attributes::NORMAL | Attributes::VALID,
+                NORMAL_CACHEABLE | Attributes::VALID,
             )
             .unwrap();
         assert_eq!(
@@ -618,7 +620,7 @@ mod tests {
         pagetable
             .map_range(
                 &MemoryRegion::new(0, 1 << 30),
-                Attributes::NORMAL | Attributes::VALID,
+                NORMAL_CACHEABLE | Attributes::VALID,
             )
             .unwrap();
         assert_eq!(
@@ -630,7 +632,7 @@ mod tests {
     fn make_map() -> LinearMap {
         let mut lmap = LinearMap::new(1, 1, 4096, TranslationRegime::El1And0, VaRange::Lower);
         // Mapping VA range 0x0 - 0x2000 to PA range 0x1000 - 0x3000
-        lmap.map_range(&MemoryRegion::new(0, PAGE_SIZE * 2), Attributes::NORMAL)
+        lmap.map_range(&MemoryRegion::new(0, PAGE_SIZE * 2), NORMAL_CACHEABLE)
             .unwrap();
         lmap
     }
@@ -677,12 +679,12 @@ mod tests {
         let mut lmap = LinearMap::new(1, 1, 0x1000, TranslationRegime::El1And0, VaRange::Lower);
         lmap.map_range(
             &MemoryRegion::new(0, BLOCK_RANGE),
-            Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::SWFLAG_0,
+            NORMAL_CACHEABLE | Attributes::NON_GLOBAL | Attributes::SWFLAG_0,
         )
         .unwrap();
         lmap.map_range(
             &MemoryRegion::new(0, PAGE_SIZE),
-            Attributes::NORMAL | Attributes::NON_GLOBAL | Attributes::VALID,
+            NORMAL_CACHEABLE | Attributes::NON_GLOBAL | Attributes::VALID,
         )
         .unwrap();
         lmap.modify_range(

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -513,10 +513,17 @@ bitflags! {
         const VALID         = 1 << 0;
         const TABLE_OR_PAGE = 1 << 1;
 
-        // The following memory types assume that the MAIR registers
-        // have been programmed accordingly.
-        const DEVICE_NGNRE  = 0 << 2;
-        const NORMAL        = 1 << 2 | 3 << 8; // inner shareable
+        const ATTRIBUTE_INDEX_0 = 0 << 2;
+        const ATTRIBUTE_INDEX_1 = 1 << 2;
+        const ATTRIBUTE_INDEX_2 = 2 << 2;
+        const ATTRIBUTE_INDEX_3 = 3 << 2;
+        const ATTRIBUTE_INDEX_4 = 4 << 2;
+        const ATTRIBUTE_INDEX_5 = 5 << 2;
+        const ATTRIBUTE_INDEX_6 = 6 << 2;
+        const ATTRIBUTE_INDEX_7 = 7 << 2;
+
+        const OUTER_SHAREABLE = 2 << 8;
+        const INNER_SHAREABLE = 3 << 8;
 
         const NS            = 1 << 5;
         const USER          = 1 << 6;
@@ -536,6 +543,14 @@ bitflags! {
         const SWFLAG_2 = 1 << 57;
         const SWFLAG_3 = 1 << 58;
     }
+}
+
+impl Attributes {
+    /// Mask for the bits determining the shareability of the mapping.
+    pub const SHAREABILITY_MASK: Self = Self::INNER_SHAREABLE;
+
+    /// Mask for the bits determining the attribute index of the mapping.
+    pub const ATTRIBUTE_INDEX_MASK: Self = Self::ATTRIBUTE_INDEX_7;
 }
 
 /// Smart pointer which owns a [`PageTable`] and knows what level it is at. This allows it to

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -526,7 +526,7 @@ bitflags! {
         const DBM           = 1 << 51;
         const EXECUTE_NEVER = 3 << 53;
 
-        /// Software flags in block and page descriptor entries.
+        // Software flags in block and page descriptor entries.
         const SWFLAG_0 = 1 << 55;
         const SWFLAG_1 = 1 << 56;
         const SWFLAG_2 = 1 << 57;

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -524,7 +524,11 @@ bitflags! {
         const ACCESSED      = 1 << 10;
         const NON_GLOBAL    = 1 << 11;
         const DBM           = 1 << 51;
-        const EXECUTE_NEVER = 3 << 53;
+        /// Privileged Execute-never, if two privilege levels are supported.
+        const PXN           = 1 << 53;
+        /// Unprivileged Execute-never, or just Execute-never if only one privilege level is
+        /// supported.
+        const UXN           = 1 << 54;
 
         // Software flags in block and page descriptor entries.
         const SWFLAG_0 = 1 << 55;

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -518,6 +518,7 @@ bitflags! {
         const DEVICE_NGNRE  = 0 << 2;
         const NORMAL        = 1 << 2 | 3 << 8; // inner shareable
 
+        const NS            = 1 << 5;
         const USER          = 1 << 6;
         const READ_ONLY     = 1 << 7;
         const ACCESSED      = 1 << 10;


### PR DESCRIPTION
This adds some attribute bits relevant to other translation regimes. I've also removed the assumption that MAIR registers are programmed a particular way. It should be up to the user of the library to decide how they want to use the different memory attributes, so this library can just provide flags for the attribute indices and the user can define their own constants based on that.