### PR TITLE
Don't require Translation to be Clone, and pass `&mut self` to allocation methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Other changes
+
+- The `Translation` type parameter to `Mappping` no longer needs to be `Clone`.
+
 ## 0.6.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- `Translation::allocate_table` and `Translation::deallocate_table` now takes `&mut self` rather
+  than `&self.
+
 ### Other changes
 
 - The `Translation` type parameter to `Mappping` no longer needs to be `Clone`.

--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -26,7 +26,7 @@ impl IdTranslation {
 }
 
 impl Translation for IdTranslation {
-    fn allocate_table(&self) -> (NonNull<PageTable>, PhysicalAddress) {
+    fn allocate_table(&mut self) -> (NonNull<PageTable>, PhysicalAddress) {
         let table = PageTable::new();
 
         // Physical address is the same as the virtual address because we are using identity mapping
@@ -34,7 +34,7 @@ impl Translation for IdTranslation {
         (table, PhysicalAddress(table.as_ptr() as usize))
     }
 
-    unsafe fn deallocate_table(&self, page_table: NonNull<PageTable>) {
+    unsafe fn deallocate_table(&mut self, page_table: NonNull<PageTable>) {
         deallocate(page_table);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ impl Display for MapError {
 /// switch back to a previous static page table, and then `activate` again after making the desired
 /// changes.
 #[derive(Debug)]
-pub struct Mapping<T: Translation + Clone> {
+pub struct Mapping<T: Translation> {
     root: RootTable<T>,
     #[allow(unused)]
     asid: usize,
@@ -118,7 +118,7 @@ pub struct Mapping<T: Translation + Clone> {
     previous_ttbr: Option<usize>,
 }
 
-impl<T: Translation + Clone> Mapping<T> {
+impl<T: Translation> Mapping<T> {
     /// Creates a new page table with the given ASID, root level and translation mapping.
     pub fn new(
         translation: T,
@@ -489,7 +489,7 @@ impl<T: Translation + Clone> Mapping<T> {
     }
 }
 
-impl<T: Translation + Clone> Drop for Mapping<T> {
+impl<T: Translation> Drop for Mapping<T> {
     fn drop(&mut self) {
         if self.previous_ttbr.is_some() {
             #[cfg(target_arch = "aarch64")]

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -48,7 +48,7 @@ impl LinearTranslation {
 }
 
 impl Translation for LinearTranslation {
-    fn allocate_table(&self) -> (NonNull<PageTable>, PhysicalAddress) {
+    fn allocate_table(&mut self) -> (NonNull<PageTable>, PhysicalAddress) {
         let table = PageTable::new();
         // Assume that the same linear mapping is used everywhere.
         let va = VirtualAddress(table.as_ptr() as usize);
@@ -59,7 +59,7 @@ impl Translation for LinearTranslation {
         (table, pa)
     }
 
-    unsafe fn deallocate_table(&self, page_table: NonNull<PageTable>) {
+    unsafe fn deallocate_table(&mut self, page_table: NonNull<PageTable>) {
         deallocate(page_table);
     }
 


### PR DESCRIPTION
This should make it easier for users of the library to keep state in their `Translation` implementation if they want to.