### PR TITLE
Make PageTableWithLevel (and types containing it) Sync.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ### Other changes
 
-- The `Translation` type parameter to `Mappping` no longer needs to be `Clone`.
+- The `Translation` type parameter to `Mapping` no longer needs to be `Clone`.
+- `IdMap`, `LinearMap`, `Mapping` and `RootTable` are now `Sync`.
 
 ## 0.6.0
 

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -567,6 +567,9 @@ struct PageTableWithLevel<T: Translation> {
 // with appropriate synchronization. This type manages ownership for the raw pointer.
 unsafe impl<T: Translation + Send> Send for PageTableWithLevel<T> {}
 
+// SAFETY: &Self only allows reading from the page table, which is safe to do from any thread.
+unsafe impl<T: Translation + Sync> Sync for PageTableWithLevel<T> {}
+
 impl<T: Translation> PageTableWithLevel<T> {
     /// Allocates a new, zeroed, appropriately-aligned page table with the given translation,
     /// returning both a pointer to it and its physical address.


### PR DESCRIPTION
There's no reason for them not to be, a shared reference to them is safe to use from any thread.