### PR TITLE
Deny unsafe_op_in_unsafe_fn.

### DIFF
--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -35,7 +35,12 @@ impl Translation for IdTranslation {
     }
 
     unsafe fn deallocate_table(&mut self, page_table: NonNull<PageTable>) {
-        deallocate(page_table);
+        // SAFETY: Our caller promises that the memory was allocated by `allocate_table` on this
+        // `IdTranslation` and not yet deallocated. `allocate_table` used the global allocator and
+        // appropriate layout by calling `PageTable::new()`.
+        unsafe {
+            deallocate(page_table);
+        }
     }
 
     fn physical_to_virtual(&self, pa: PhysicalAddress) -> NonNull<PageTable> {
@@ -133,7 +138,10 @@ impl IdMap {
     /// dropped as long as its mappings are required, as it will automatically be deactivated when
     /// it is dropped.
     pub unsafe fn activate(&mut self) {
-        self.mapping.activate()
+        // SAFETY: We delegate the safety requirements to our caller.
+        unsafe {
+            self.mapping.activate();
+        }
     }
 
     /// Deactivates the page table, by setting `TTBR0_EL1` back to the value it had before
@@ -150,7 +158,10 @@ impl IdMap {
     /// The caller must ensure that the previous page table which this is switching back to doesn't
     /// unmap any memory which the program is using.
     pub unsafe fn deactivate(&mut self) {
-        self.mapping.deactivate()
+        // SAFETY: We delegate the safety requirements to our caller.
+        unsafe {
+            self.mapping.deactivate();
+        }
     }
 
     /// Maps the given range of virtual addresses to the identical physical addresses with the given

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@
 
 #![no_std]
 #![deny(clippy::undocumented_unsafe_blocks)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 #[cfg(feature = "alloc")]
 pub mod idmap;
@@ -163,9 +164,8 @@ impl<T: Translation> Mapping<T> {
         let mut previous_ttbr = usize::MAX;
 
         #[cfg(all(not(test), target_arch = "aarch64"))]
-        // SAFETY: Safe because we trust that self.root_address() returns a valid physical address
-        // of a page table, and the `Drop` implementation will reset `TTBRn_ELx` before it becomes
-        // invalid.
+        // SAFETY: We trust that self.root_address() returns a valid physical address of a page
+        // table, and the `Drop` implementation will reset `TTBRn_ELx` before it becomes invalid.
         unsafe {
             match (self.root.translation_regime(), self.root.va_range()) {
                 (TranslationRegime::El1And0, VaRange::Lower) => asm!(
@@ -241,8 +241,8 @@ impl<T: Translation> Mapping<T> {
         assert!(self.active());
 
         #[cfg(all(not(test), target_arch = "aarch64"))]
-        // SAFETY: Safe because this just restores the previously saved value of `TTBRn_ELx`, which
-        // must have been valid.
+        // SAFETY: This just restores the previously saved value of `TTBRn_ELx`, which must have
+        // been valid.
         unsafe {
             match (self.root.translation_regime(), self.root.va_range()) {
                 (TranslationRegime::El1And0, VaRange::Lower) => asm!(
@@ -391,7 +391,7 @@ impl<T: Translation> Mapping<T> {
         }
         self.root.map_range(range, pa, flags, constraints)?;
         #[cfg(target_arch = "aarch64")]
-        // SAFETY: Safe because this is just a memory barrier.
+        // SAFETY: This is just a memory barrier.
         unsafe {
             asm!("dsb ishst");
         }
@@ -430,7 +430,7 @@ impl<T: Translation> Mapping<T> {
         }
         self.root.modify_range(range, f)?;
         #[cfg(target_arch = "aarch64")]
-        // SAFETY: Safe because this is just a memory barrier.
+        // SAFETY: This is just a memory barrier.
         unsafe {
             asm!("dsb ishst");
         }

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -60,7 +60,12 @@ impl Translation for LinearTranslation {
     }
 
     unsafe fn deallocate_table(&mut self, page_table: NonNull<PageTable>) {
-        deallocate(page_table);
+        // SAFETY: Our caller promises that the memory was allocated by `allocate_table` on this
+        // `LinearTranslation` and not yet deallocated. `allocate_table` used the global allocator
+        // and appropriate layout by calling `PageTable::new()`.
+        unsafe {
+            deallocate(page_table);
+        }
     }
 
     fn physical_to_virtual(&self, pa: PhysicalAddress) -> NonNull<PageTable> {
@@ -139,7 +144,10 @@ impl LinearMap {
     /// dropped as long as its mappings are required, as it will automatically be deactivated when
     /// it is dropped.
     pub unsafe fn activate(&mut self) {
-        self.mapping.activate()
+        // SAFETY: We delegate the safety requirements to our caller.
+        unsafe {
+            self.mapping.activate();
+        }
     }
 
     /// Deactivates the page table, by setting `TTBRn_EL1` back to the value it had before
@@ -156,7 +164,10 @@ impl LinearMap {
     /// The caller must ensure that the previous page table which this is switching back to doesn't
     /// unmap any memory which the program is using.
     pub unsafe fn deactivate(&mut self) {
-        self.mapping.deactivate()
+        // SAFETY: We delegate the safety requirements to our caller.
+        unsafe {
+            self.mapping.deactivate();
+        }
     }
 
     /// Maps the given range of virtual addresses to the corresponding physical addresses with the


### PR DESCRIPTION
Also changed safety comments to a consistent style. There is no functional change.