### PR TITLE
Make `output_address` method on `Descriptor` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 - `MapError` now implements `core::error::Error`.
+- Made `output_address` method on `Descriptor` public.
 
 ## 0.8.0
 

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -890,6 +890,10 @@ impl Descriptor {
 
     const PHYSICAL_ADDRESS_BITMASK: usize = !(PAGE_SIZE - 1) & !(0xffff << 48);
 
+    /// Returns the physical address that this descriptor refers to if it is valid.
+    ///
+    /// Depending on the flags this could be the address of a subtable, a mapping, or (if it is not
+    /// a valid mapping) entirely arbitrary.
     pub fn output_address(self) -> PhysicalAddress {
         PhysicalAddress(self.0 & Self::PHYSICAL_ADDRESS_BITMASK)
     }

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -890,7 +890,7 @@ impl Descriptor {
 
     const PHYSICAL_ADDRESS_BITMASK: usize = !(PAGE_SIZE - 1) & !(0xffff << 48);
 
-    pub(crate) fn output_address(self) -> PhysicalAddress {
+    pub fn output_address(self) -> PhysicalAddress {
         PhysicalAddress(self.0 & Self::PHYSICAL_ADDRESS_BITMASK)
     }
 


### PR DESCRIPTION
Needed this for a project, thought I'd see if anyone else wanted it upstreamed.