### PR TITLE
Document that only 64-bit page table descriptors are supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Currently it only supports:
 - stage 1 page tables
 - 4 KiB pages
 - EL3, NS-EL2, NS-EL2&0 and NS-EL1&0 translation regimes
+- 64-bit descriptors
 
 This is not an officially supported Google product.
 


### PR DESCRIPTION
ARMv9 introduces support for 128-bit page table descriptors, which completely changes how the page table hierarchy is constructed. This is not trivial to support, and therefore not attempted for the time being.