### PR TITLE
Return Attributes from Descriptor::flags even if there are unknown bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- `Descriptor::flags` now returns `Attributes` rather than `Option<Attributes>`. If any unknown bits
+  are set they will be included.
+
+### Bug fixes
+
+- `Descriptor::is_table_or_page` will return the correct value even if unknown bits are set.
+  Previously it would return false in this case.
+
 ## 0.8.1
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - `Descriptor::is_table_or_page` will return the correct value even if unknown bits are set.
   Previously it would return false in this case.
 
+### New features
+
+- Added `PXN_TABLE`, `XN_TABLE`, `AP_TABLE_NO_EL0`, `AP_TABLE_NO_WRITE` and `NS_TABLE` bits to
+  `Attributes`.
+
 ## 0.8.1
 
 ### New features

--- a/src/idmap.rs
+++ b/src/idmap.rs
@@ -675,7 +675,7 @@ mod tests {
         idmap
             .modify_range(&MemoryRegion::new(1, PAGE_SIZE), &|range, entry, level| {
                 if level == 3 || !entry.is_table_or_page() {
-                    assert!(entry.flags().unwrap().contains(Attributes::SWFLAG_0));
+                    assert!(entry.flags().contains(Attributes::SWFLAG_0));
                     assert_eq!(range.end() - range.start(), PAGE_SIZE);
                 }
                 Ok(())
@@ -712,7 +712,7 @@ mod tests {
                 &MemoryRegion::new(0, BLOCK_RANGE),
                 &|range, entry, level| {
                     if level == 3 {
-                        let has_swflag = entry.flags().unwrap().contains(Attributes::SWFLAG_0);
+                        let has_swflag = entry.flags().contains(Attributes::SWFLAG_0);
                         let is_first_page = range.start().0 == 0usize;
                         assert!(has_swflag != is_first_page);
                     }
@@ -738,7 +738,7 @@ mod tests {
                 &MemoryRegion::new(PAGE_SIZE, PAGE_SIZE * 20),
                 &mut |_, descriptor, _| {
                     assert!(!descriptor.is_valid());
-                    assert_eq!(descriptor.flags(), Some(Attributes::empty()));
+                    assert_eq!(descriptor.flags(), Attributes::empty());
                     assert_eq!(descriptor.output_address(), PhysicalAddress(0));
                     Ok(())
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,7 @@ impl<T: Translation> Mapping<T> {
                     let (flags, oa) = {
                         let mut dd = *d;
                         updater(mr, &mut dd, level).or(Err(err.clone()))?;
-                        (dd.flags().ok_or(err.clone())?, dd.output_address())
+                        (dd.flags(), dd.output_address())
                     };
 
                     if !flags.contains(Attributes::VALID) {
@@ -333,7 +333,7 @@ impl<T: Translation> Mapping<T> {
                         return Err(err);
                     }
 
-                    let desc_flags = d.flags().unwrap();
+                    let desc_flags = d.flags();
 
                     if (desc_flags ^ flags).intersects(
                         Attributes::ATTRIBUTE_INDEX_MASK | Attributes::SHAREABILITY_MASK,

--- a/src/linearmap.rs
+++ b/src/linearmap.rs
@@ -683,7 +683,7 @@ mod tests {
         .unwrap();
         lmap.modify_range(&MemoryRegion::new(1, PAGE_SIZE), &|range, entry, level| {
             if level == 3 || !entry.is_table_or_page() {
-                assert!(entry.flags().unwrap().contains(Attributes::SWFLAG_0));
+                assert!(entry.flags().contains(Attributes::SWFLAG_0));
                 assert_eq!(range.end() - range.start(), PAGE_SIZE);
             }
             Ok(())
@@ -710,7 +710,7 @@ mod tests {
             &MemoryRegion::new(0, BLOCK_RANGE),
             &|range, entry, level| {
                 if level == 3 {
-                    let has_swflag = entry.flags().unwrap().contains(Attributes::SWFLAG_0);
+                    let has_swflag = entry.flags().contains(Attributes::SWFLAG_0);
                     let is_first_page = range.start().0 == 0usize;
                     assert!(has_swflag != is_first_page);
                 }

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -554,6 +554,12 @@ bitflags! {
         const SWFLAG_1 = 1 << 56;
         const SWFLAG_2 = 1 << 57;
         const SWFLAG_3 = 1 << 58;
+
+        const PXN_TABLE = 1 << 59;
+        const XN_TABLE = 1 << 60;
+        const AP_TABLE_NO_EL0 = 1 << 61;
+        const AP_TABLE_NO_WRITE = 1 << 62;
+        const NS_TABLE = 1 << 63;
     }
 }
 

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1155,4 +1155,33 @@ mod tests {
     fn no_el3_ttbr1() {
         RootTable::<IdTranslation>::new(IdTranslation, 1, TranslationRegime::El3, VaRange::Upper);
     }
+
+    #[test]
+    fn table_or_page() {
+        // Invalid.
+        assert!(!Descriptor(0b00).is_table_or_page());
+        assert!(!Descriptor(0b10).is_table_or_page());
+
+        // Block mapping.
+        assert!(!Descriptor(0b01).is_table_or_page());
+
+        // Table or page.
+        assert!(Descriptor(0b11).is_table_or_page());
+    }
+
+    #[test]
+    fn table_or_page_unknown_bits() {
+        // Some RES0 and IGNORED bits that we set for the sake of the test.
+        const UNKNOWN: usize = 1 << 50 | 1 << 52;
+
+        // Invalid.
+        assert!(!Descriptor(UNKNOWN | 0b00).is_table_or_page());
+        assert!(!Descriptor(UNKNOWN | 0b10).is_table_or_page());
+
+        // Block mapping.
+        assert!(!Descriptor(UNKNOWN | 0b01).is_table_or_page());
+
+        // Table or page.
+        assert!(Descriptor(UNKNOWN | 0b11).is_table_or_page());
+    }
 }


### PR DESCRIPTION
This fixes #67.

Also added some more bits to `Attributes`.
