### PR TITLE
Deal with memory ordering in page tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,6 @@ version = "0.9.1"
 dependencies = [
  "bitflags",
  "thiserror",
- "zerocopy",
 ]
 
 [[package]]
@@ -71,23 +70,3 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,10 @@ categories = ["embedded", "no-std", "hardware-support"]
 [dependencies]
 bitflags = "2.9.0"
 thiserror = { version = "2.0.3", default-features = false }
-zerocopy = { version = "0.8.25", features = ["derive"], optional = true }
 
 [features]
-default = ["alloc", "zerocopy"]
+default = ["alloc"]
 alloc = []
-zerocopy = ["dep:zerocopy"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/target.rs
+++ b/src/target.rs
@@ -9,8 +9,6 @@
 use crate::paging::{PageTable, PhysicalAddress, Translation, deallocate};
 use alloc::{vec, vec::Vec};
 use core::{mem::size_of, ptr::NonNull};
-#[cfg(feature = "zerocopy")]
-use zerocopy::IntoBytes;
 
 /// An implementation of `Translation` which builds a static pagetable to be built into a binary for
 /// some target device.
@@ -88,7 +86,6 @@ impl TargetAllocator {
     /// Returns the full page table as bytes to be loaded into the target device's memory.
     ///
     /// This could be embedded in a binary image for the target.
-    #[cfg(feature = "zerocopy")]
     pub fn as_bytes(&self) -> Vec<u8> {
         let mut bytes = vec![0; self.allocations.len() * size_of::<PageTable>()];
         for (chunk, allocation) in bytes


### PR DESCRIPTION
Even though we model them as arbitrary arrays of usize in memory, live page tables are actually referenced by the page table walker, which is a separate observer in ARM ARM parlance.

So instead, treat it as an array of AtomicUsize, so that we obtain the following properties:

- no Copy or Clone traits, and so all manipulations of descriptors are guaranteed to operate on the descriptor directly, using atomic accesses

- all stores are issued with release semantics, which guarantees that th page table walker cannot observe stores in the wrong order (e.g., a table entry being updated before the table in question has been fully populated)

The Descriptor type does implement clone(), for where it is needed explicitly (there is a single case where a descriptor is copied into a variable to perform checks on it).

Unfortunately, the zerocopy crate only provides IntoBytes::as_bytes() for types that implement the Immutable trait, and does not (and likely should not) implement that generically for AtomicUsize.

The static page table construction implemented by this crate only relies on these properties for a very particular use case, where the distinction does not matter. So for the time being, implement Immutable for Descriptor explicitly, even though that violates the rules of the zerocopy crate.